### PR TITLE
Fix content node height overestimation

### DIFF
--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -706,7 +706,7 @@ export const buildNewDocument = (
         oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc);
 
         currentPageContent.push(node);
-        currentHeight += Math.max(nodeHeight, MIN_PARAGRAPH_HEIGHT);
+        currentHeight += nodeHeight;
     }
 
     if (currentPageContent.length > 0) {


### PR DESCRIPTION
Don't use minimum node height when calculating current page height in build algorithm