### PR TITLE
Feat: table splitting

### DIFF
--- a/src/Plugins/Pagination.ts
+++ b/src/Plugins/Pagination.ts
@@ -4,11 +4,8 @@
  * @description Custom plugin for paginating the editor content.
  */
 
-import { EditorState,Plugin, PluginKey } from "@tiptap/pm/state";
+import { Plugin, PluginKey, EditorState } from "@tiptap/pm/state";
 import { EditorView } from "@tiptap/pm/view";
-
-import { isNodeEmpty } from "../utils/node";
-import { doesDocHavePageNodes } from "../utils/page";
 import {
     buildNewDocument,
     collectContentNodes,
@@ -16,6 +13,8 @@ import {
     measureNodeHeights,
     paginationUpdateCursorPosition,
 } from "../utils/pagination";
+import { isNodeEmpty } from "../utils/node";
+import { doesDocHavePageNodes } from "../utils/page";
 
 const PaginationPlugin = new Plugin({
     key: new PluginKey("pagination"),
@@ -50,7 +49,7 @@ const PaginationPlugin = new Plugin({
 
                     const { newDoc, oldToNewPosMap } = buildNewDocument(state, contentNodes, nodeHeights, view);
 
-                    const {tr} = state;
+                    const tr = state.tr;
                     // Compare the content of the documents
                     if (!newDoc.content.eq(doc.content)) {
                         tr.replaceWith(0, doc.content.size, newDoc.content);

--- a/src/Plugins/Pagination.ts
+++ b/src/Plugins/Pagination.ts
@@ -4,84 +4,74 @@
  * @description Custom plugin for paginating the editor content.
  */
 
-import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
-import { EditorView } from '@tiptap/pm/view'
+import { EditorState,Plugin, PluginKey } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
 
-import { isNodeEmpty } from '../utils/node'
-import { doesDocHavePageNodes } from '../utils/page'
+import { isNodeEmpty } from "../utils/node";
+import { doesDocHavePageNodes } from "../utils/page";
 import {
-  buildNewDocument,
-  collectContentNodes,
-  mapCursorPosition,
-  measureNodeHeights,
-  paginationUpdateCursorPosition,
-} from '../utils/pagination'
+    buildNewDocument,
+    collectContentNodes,
+    mapCursorPosition,
+    measureNodeHeights,
+    paginationUpdateCursorPosition,
+} from "../utils/pagination";
 
 const PaginationPlugin = new Plugin({
-  key: new PluginKey('pagination'),
-  view() {
-    let isPaginating = false
+    key: new PluginKey("pagination"),
+    view() {
+        let isPaginating = false;
 
-    return {
-      update(view: EditorView, prevState: EditorState) {
-        if (isPaginating) return
+        return {
+            update(view: EditorView, prevState: EditorState) {
+                if (isPaginating) return;
 
-        const { state, dispatch } = view
-        const { doc, schema } = state
-        const pageType = schema.nodes.page
+                const { state, dispatch } = view;
+                const { doc, schema } = state;
+                const pageType = schema.nodes.page;
 
-        if (!pageType) return
+                if (!pageType) return;
 
-        const docChanged = !doc.eq(prevState.doc)
-        const initialLoad = isNodeEmpty(prevState.doc) && !isNodeEmpty(doc)
-        const hasPageNodes = doesDocHavePageNodes(state)
+                const docChanged = !doc.eq(prevState.doc);
+                const initialLoad = isNodeEmpty(prevState.doc) && !isNodeEmpty(doc);
+                const hasPageNodes = doesDocHavePageNodes(state);
 
-        if (!docChanged && hasPageNodes && !initialLoad) return
+                if (!docChanged && hasPageNodes && !initialLoad) return;
 
-        isPaginating = true
+                isPaginating = true;
 
-        try {
-          const contentNodes = collectContentNodes(state)
-          const nodeHeights = measureNodeHeights(view, contentNodes)
+                try {
+                    const contentNodes = collectContentNodes(state);
+                    const nodeHeights = measureNodeHeights(view, contentNodes);
 
-          // Record the cursor's old position
-          const { selection } = state
-          const oldCursorPos = selection.from
+                    // Record the cursor's old position
+                    const { selection } = state;
+                    const oldCursorPos = selection.from;
 
-          const { newDoc, oldToNewPosMap } = buildNewDocument(
-            state,
-            contentNodes,
-            nodeHeights,
-            view,
-          )
+                    const { newDoc, oldToNewPosMap } = buildNewDocument(state, contentNodes, nodeHeights, view);
 
-          const { tr } = state
-          // Compare the content of the documents
-          if (!newDoc.content.eq(doc.content)) {
-            tr.replaceWith(0, doc.content.size, newDoc.content)
-            tr.setMeta('pagination', true)
+                    const {tr} = state;
+                    // Compare the content of the documents
+                    if (!newDoc.content.eq(doc.content)) {
+                        tr.replaceWith(0, doc.content.size, newDoc.content);
+                        tr.setMeta("pagination", true);
 
-            const newDocContentSize = newDoc.content.size
-            const newCursorPos = mapCursorPosition(
-              contentNodes,
-              oldCursorPos,
-              oldToNewPosMap,
-              newDocContentSize,
-            )
-            paginationUpdateCursorPosition(tr, newCursorPos)
-          }
+                        const newDocContentSize = newDoc.content.size;
+                        const newCursorPos = mapCursorPosition(contentNodes, oldCursorPos, oldToNewPosMap, newDocContentSize);
+                        paginationUpdateCursorPosition(tr, newCursorPos);
+                    }
 
-          dispatch(tr)
-        } catch (error) {
-          console.error('Error updating page view. Details:', error)
-        }
+                    dispatch(tr);
+                } catch (error) {
+                    console.error("Error updating page view. Details:", error);
+                }
 
-        // Reset paginating flag regardless of success or failure because we do not want to get
-        // stuck out of this loop.
-        isPaginating = false
-      },
-    }
-  },
-})
+                // Reset paginating flag regardless of success or failure because we do not want to get
+                // stuck out of this loop.
+                isPaginating = false;
+            },
+        };
+    },
+});
 
-export default PaginationPlugin
+export default PaginationPlugin;

--- a/src/Plugins/Pagination.ts
+++ b/src/Plugins/Pagination.ts
@@ -7,70 +7,80 @@
 import { Plugin, PluginKey, EditorState } from "@tiptap/pm/state";
 import { EditorView } from "@tiptap/pm/view";
 import {
-    buildNewDocument,
-    collectContentNodes,
-    mapCursorPosition,
-    measureNodeHeights,
-    paginationUpdateCursorPosition,
+  buildNewDocument,
+  collectContentNodes,
+  mapCursorPosition,
+  measureNodeHeights,
+  paginationUpdateCursorPosition,
 } from "../utils/pagination";
 import { isNodeEmpty } from "../utils/node";
 import { doesDocHavePageNodes } from "../utils/page";
 
 const PaginationPlugin = new Plugin({
-    key: new PluginKey("pagination"),
-    view() {
-        let isPaginating = false;
+  key: new PluginKey("pagination"),
+  view() {
+    let isPaginating = false;
 
-        return {
-            update(view: EditorView, prevState: EditorState) {
-                if (isPaginating) return;
+    return {
+      update(view: EditorView, prevState: EditorState) {
+        if (isPaginating) return;
 
-                const { state, dispatch } = view;
-                const { doc, schema } = state;
-                const pageType = schema.nodes.page;
+        const { state, dispatch } = view;
+        const { doc, schema } = state;
+        const pageType = schema.nodes.page;
 
-                if (!pageType) return;
+        if (!pageType) return;
 
-                const docChanged = !doc.eq(prevState.doc);
-                const initialLoad = isNodeEmpty(prevState.doc) && !isNodeEmpty(doc);
-                const hasPageNodes = doesDocHavePageNodes(state);
+        const docChanged = !doc.eq(prevState.doc);
+        const initialLoad = isNodeEmpty(prevState.doc) && !isNodeEmpty(doc);
+        const hasPageNodes = doesDocHavePageNodes(state);
 
-                if (!docChanged && hasPageNodes && !initialLoad) return;
+        if (!docChanged && hasPageNodes && !initialLoad) return;
 
-                isPaginating = true;
+        isPaginating = true;
 
-                try {
-                    const contentNodes = collectContentNodes(state);
-                    const nodeHeights = measureNodeHeights(view, contentNodes);
+        try {
+          const contentNodes = collectContentNodes(state);
+          const nodeHeights = measureNodeHeights(view, contentNodes);
 
-                    // Record the cursor's old position
-                    const { selection } = state;
-                    const oldCursorPos = selection.from;
+          // Record the cursor's old position
+          const { selection } = state;
+          const oldCursorPos = selection.from;
 
-                    const { newDoc, oldToNewPosMap } = buildNewDocument(state, contentNodes, nodeHeights, view);
+          const { newDoc, oldToNewPosMap } = buildNewDocument(
+            state,
+            contentNodes,
+            nodeHeights,
+            view
+          );
 
-                    const tr = state.tr;
-                    // Compare the content of the documents
-                    if (!newDoc.content.eq(doc.content)) {
-                        tr.replaceWith(0, doc.content.size, newDoc.content);
-                        tr.setMeta("pagination", true);
+          const tr = state.tr;
+          // Compare the content of the documents
+          if (!newDoc.content.eq(doc.content)) {
+            tr.replaceWith(0, doc.content.size, newDoc.content);
+            tr.setMeta("pagination", true);
 
-                        const newDocContentSize = newDoc.content.size;
-                        const newCursorPos = mapCursorPosition(contentNodes, oldCursorPos, oldToNewPosMap, newDocContentSize);
-                        paginationUpdateCursorPosition(tr, newCursorPos);
-                    }
+            const newDocContentSize = newDoc.content.size;
+            const newCursorPos = mapCursorPosition(
+              contentNodes,
+              oldCursorPos,
+              oldToNewPosMap,
+              newDocContentSize
+            );
+            paginationUpdateCursorPosition(tr, newCursorPos);
+          }
 
-                    dispatch(tr);
-                } catch (error) {
-                    console.error("Error updating page view. Details:", error);
-                }
+          dispatch(tr);
+        } catch (error) {
+          console.error("Error updating page view. Details:", error);
+        }
 
-                // Reset paginating flag regardless of success or failure because we do not want to get
-                // stuck out of this loop.
-                isPaginating = false;
-            },
-        };
-    },
+        // Reset paginating flag regardless of success or failure because we do not want to get
+        // stuck out of this loop.
+        isPaginating = false;
+      },
+    };
+  },
 });
 
 export default PaginationPlugin;

--- a/src/constants/table.ts
+++ b/src/constants/table.ts
@@ -1,0 +1,1 @@
+export const TABLE_NODE_TYPE = 'table';

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -1,0 +1,31 @@
+import { Node as PMNode } from '@tiptap/pm/model' 
+
+/**
+ * A type definition for a table measurement.
+ */
+export type TableMeasurement = {
+  rowHeights: number[];
+  headerRowCount: number;
+  totalHeight: number;
+  breakPoints: number[];
+  cumulativeHeights: number[];
+}
+
+/**
+ * A type definition for a table split result.
+ */
+export type TableSplitResult = {
+  tables: PMNode[];
+  mapping: { from: number; to: number }[];
+  groupId: string;
+  measurements: TableMeasurement[];
+}
+
+/**
+ * A type definition for a table group.
+ */
+export type TableGroup  = {
+  tables: PMNode[];
+  originalTable: PMNode;
+  positions: number[];
+}

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -16,7 +16,7 @@ export type TableMeasurement = {
  */
 export type TableSplitResult = {
   tables: PMNode[];
-  mapping: { from: number; to: number }[];
+  mapping: TableMapping[];
   groupId: string;
   measurements: TableMeasurement[];
 }
@@ -24,8 +24,13 @@ export type TableSplitResult = {
 /**
  * A type definition for a table group.
  */
-export type TableGroup  = {
+export type TableGroup = {
   tables: PMNode[];
   originalTable: PMNode;
   positions: number[];
+}
+
+export type TableMapping = {
+    from: number; 
+    to: number;
 }

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -710,24 +710,21 @@ export const buildNewDocument = (
           const oldPoses: number[] = []
           if (!node.attrs.groupId) {
             const measurement = tableHandler.measureTable(node, oldPos, view)
-
-            if (isPageFull) {
-              // this has already checked whether the node fits
-              const {
-                tables: optimisedTables,
-                measurements: optimisedMeasurements,
-              } = tableHandler.splitTableAtHeight(
-                node,
-                availableHeight,
-                measurement,
-                schema,
-                pagePixelDimensions.pageContentHeight,
-              )
-              tables = optimisedTables.filter((table) =>
-                table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
-              )
-              measurements = optimisedMeasurements.slice(0, tables.length)
-            }
+            const {
+              tables: optimisedTables,
+              measurements: optimisedMeasurements,
+            } = tableHandler.splitTableAtHeight(
+              node,
+              availableHeight,
+              measurement,
+              schema,
+              pagePixelDimensions.pageContentHeight,
+            )
+            tables = optimisedTables.filter((table) =>
+              table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
+            )
+            measurements = optimisedMeasurements.slice(0, tables.length)
+          
           } else {
             const groupTables = contentNodes.filter(
               (n) =>
@@ -794,6 +791,7 @@ export const buildNewDocument = (
                 ;({ pageNodeAttributes, pagePixelDimensions } =
                   getCalculatedPageNodeAttributes(state, pageNum))
               }
+              console.log('hererereh')
             } else {
               currentPageContent.push(table)
               currentHeight += measurements[index].totalHeight

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -791,7 +791,6 @@ export const buildNewDocument = (
                 ;({ pageNodeAttributes, pagePixelDimensions } =
                   getCalculatedPageNodeAttributes(state, pageNum))
               }
-              console.log('hererereh')
             } else {
               currentPageContent.push(table)
               currentHeight += measurements[index].totalHeight

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -691,25 +691,15 @@ export const buildNewDocument = (
         const nodeHeight = nodeHeights[i];
 
         const isPageFull = currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight && currentPageContent.length > 0;
-        const isTable = node.type.name === 'table'
+        const isTable = node.type.name === 'table';
         if (isTable) {
-          /**
-           * LOGIC
-           * if no groupId, measure the table and split based on either available height or pageContentHeight
-           * if already split
-           *  - gather tables
-           *  - for each table check against available height or max height
-           *  - if overflows, move rows to the next table (if not exist, create)
-           *  - if underflows, check if rows from next table can be moved to this table
-           *
-           */
           let tables: PMNode[] = [],
-            measurements: TableMeasurement[] = []
+            measurements: TableMeasurement[] = [];
           const availableHeight =
-            pagePixelDimensions.pageContentHeight - currentHeight
-          const oldPoses: number[] = []
+            pagePixelDimensions.pageContentHeight - currentHeight;
+          const oldPoses: number[] = [];
           if (!node.attrs.groupId) {
-            const measurement = tableHandler.measureTable(node, oldPos, view)
+            const measurement = tableHandler.measureTable(node, oldPos, view);
             const {
               tables: optimisedTables,
               measurements: optimisedMeasurements,
@@ -719,12 +709,11 @@ export const buildNewDocument = (
               measurement,
               schema,
               pagePixelDimensions.pageContentHeight,
-            )
+            );
             tables = optimisedTables.filter((table) =>
               table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
-            )
-            measurements = optimisedMeasurements.slice(0, tables.length)
-          
+            );
+            measurements = optimisedMeasurements.slice(0, tables.length);
           } else {
             const groupTables = contentNodes.filter(
               (n) =>
@@ -733,11 +722,11 @@ export const buildNewDocument = (
             )
             const groupMeasurements = groupTables.map((t) =>
               tableHandler.measureTable(t.node, t.pos, view),
-            )
-            groupTables.forEach((t, i) => {
+            );
+            groupTables.forEach((t) => {
               // Store absolute position without adjustments
               oldPoses.push(t.pos)
-            })
+            });
             const { tables: optimisedTables, measurements: optimisedMeasurements } =
               tableHandler.optimiseTables(
                 groupTables.map((t) => t.node),
@@ -745,60 +734,58 @@ export const buildNewDocument = (
                 schema,
                 availableHeight,
                 pagePixelDimensions.pageContentHeight,
-              )
+              );
             tables = optimisedTables.filter((table) =>
               table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
-            )
-            measurements = optimisedMeasurements.slice(0, tables.length)
-            i += groupTables.length - 1
+            );
+            measurements = optimisedMeasurements.slice(0, tables.length);
+            i += groupTables.length - 1;
           }
 
           tables.forEach((table, index) => {
             if (!table || !table.type || table.type.name !== 'table' || !table.content) {
-              console.warn('Invalid table encountered during pagination')
-              return
+              console.warn('Invalid table encountered during pagination');
+              return;
             }
             // insert current if the first entry exceeds height
             if (index === 0 && measurements[index].totalHeight > availableHeight) {
               if (oldPoses[index]) {
                 // Calculate position based on current page content plus the table's position within the page
-                const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
-                oldToNewPosMap.set(oldPoses[index], basePos)
+                const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0);
+                oldToNewPosMap.set(oldPoses[index], basePos);
               }
-              const pageNode = addPage(currentPageContent)
-              cumulativeNewDocPos += pageNode.nodeSize
-              currentPageContent = []
-              currentHeight = 0
-              pageNum++
+              const pageNode = addPage(currentPageContent);
+              cumulativeNewDocPos += pageNode.nodeSize;
+              currentPageContent = [];
+              currentHeight = 0;
+              pageNum++;
               if (isPageNumInRange(doc, pageNum)) {
-                ;({ pageNodeAttributes, pagePixelDimensions } =
-                  getCalculatedPageNodeAttributes(state, pageNum))
+                ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
               }
             }
             if (index < tables.length - 1) {
-              currentPageContent.push(table)
+              currentPageContent.push(table);
               if (oldPoses[index]) {
                 // For tables at page boundaries, use cumulative position
-                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
-                oldToNewPosMap.set(oldPoses[index], basePos)
+                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
+                oldToNewPosMap.set(oldPoses[index], basePos);
               }
-              const pageNode = addPage(currentPageContent)
-              cumulativeNewDocPos += pageNode.nodeSize
-              currentPageContent = []
-              currentHeight = 0
-              pageNum++
+              const pageNode = addPage(currentPageContent);
+              cumulativeNewDocPos += pageNode.nodeSize;
+              currentPageContent = [];
+              currentHeight = 0;
+              pageNum++;
               if (isPageNumInRange(doc, pageNum)) {
-                ;({ pageNodeAttributes, pagePixelDimensions } =
-                  getCalculatedPageNodeAttributes(state, pageNum))
+                ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
               }
             } else {
-              currentPageContent.push(table)
-              currentHeight += measurements[index].totalHeight
+              currentPageContent.push(table);
+              currentHeight += measurements[index].totalHeight;
 
               if (oldPoses[index]) {
                 // For the last table, calculate position based on all previous content in the page
-                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
-                oldToNewPosMap.set(oldPoses[index], basePos)
+                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
+                oldToNewPosMap.set(oldPoses[index], basePos);
               }
             }
           })

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -18,7 +18,8 @@ import { inRange } from "./math";
 import { collectPageNodes, isPageNode, isPageNumInRange } from "./page";
 import { getCalculatedPageNodeAttributes } from "./getPageAttributes";
 import { MarginConfig } from "../types/paper";
-import { TableHandler, TableMeasurement } from "./table";
+import { TableMeasurement } from "../types/table";
+import { TableHandler } from "./table";
 
 /**
  * Check if the given node is a paragraph node.

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -4,31 +4,21 @@
  * @description Utility functions for paginating the editor content.
  */
 
-import { Node as PMNode, ResolvedPos } from '@tiptap/pm/model'
-import { EditorState, Transaction } from '@tiptap/pm/state'
-import { EditorView } from '@tiptap/pm/view'
-
-import { PAGE_NODE_NAME } from '../constants/page'
-import { MIN_PARAGRAPH_HEIGHT } from '../constants/tiptap'
-import { CursorMap } from '../types/cursor'
-import { NodePosArray } from '../types/node'
-import { MarginConfig } from '../types/paper'
-import { Nullable } from '../types/record'
-import { getCalculatedPageNodeAttributes } from './getPageAttributes'
-import { inRange } from './math'
-import {
-  getParentNodePosOfType,
-  getPositionNodeType,
-  isNodeEmpty,
-} from './node'
-import { collectPageNodes, isPageNode, isPageNumInRange } from './page'
-import {
-  moveToNearestValidCursorPosition,
-  moveToThisTextBlock,
-  setSelection,
-  setSelectionAtEndOfDocument,
-} from './selection'
-import { TableHandler, TableMeasurement } from './table'
+import { Node as PMNode, ResolvedPos } from "@tiptap/pm/model";
+import { EditorState, Transaction } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+import { MIN_PARAGRAPH_HEIGHT } from "../constants/tiptap";
+import { PAGE_NODE_NAME } from "../constants/page";
+import { NodePosArray } from "../types/node";
+import { CursorMap } from "../types/cursor";
+import { Nullable } from "../types/record";
+import { getParentNodePosOfType, getPositionNodeType, isNodeEmpty } from "./node";
+import { moveToNearestValidCursorPosition, moveToThisTextBlock, setSelection, setSelectionAtEndOfDocument } from "./selection";
+import { inRange } from "./math";
+import { collectPageNodes, isPageNode, isPageNumInRange } from "./page";
+import { getCalculatedPageNodeAttributes } from "./getPageAttributes";
+import { MarginConfig } from "../types/paper";
+import { TableHandler, TableMeasurement } from "./table";
 
 /**
  * Check if the given node is a paragraph node.
@@ -36,13 +26,13 @@ import { TableHandler, TableMeasurement } from './table'
  * @returns {boolean} True if the node is a paragraph node, false otherwise.
  */
 export const isParagraphNode = (node: Nullable<PMNode>): boolean => {
-  if (!node) {
-    console.warn('No node provided')
-    return false
-  }
+    if (!node) {
+        console.warn("No node provided");
+        return false;
+    }
 
-  return node.type.name === 'paragraph'
-}
+    return node.type.name === "paragraph";
+};
 
 /**
  * Check if the given node is a text node.
@@ -50,13 +40,13 @@ export const isParagraphNode = (node: Nullable<PMNode>): boolean => {
  * @returns {boolean} True if the node is a text node, false otherwise.
  */
 export const isTextNode = (node: Nullable<PMNode>): boolean => {
-  if (!node) {
-    console.warn('No node provided')
-    return false
-  }
+    if (!node) {
+        console.warn("No node provided");
+        return false;
+    }
 
-  return node.type.name === 'text'
-}
+    return node.type.name === "text";
+};
 
 /**
  * Get the type of the node at the specified position.
@@ -64,8 +54,8 @@ export const isTextNode = (node: Nullable<PMNode>): boolean => {
  * @returns The type of the node at the specified position.
  */
 export const isPositionWithinParagraph = ($pos: ResolvedPos): boolean => {
-  return getPositionNodeType($pos) === 'paragraph'
-}
+    return getPositionNodeType($pos) === "paragraph";
+};
 
 /**
  * Get the page node (parent of the current node) position.
@@ -73,12 +63,9 @@ export const isPositionWithinParagraph = ($pos: ResolvedPos): boolean => {
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The position of the page node.
  */
-export const getThisPageNodePosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): number => {
-  return getParentNodePosOfType(doc, pos, PAGE_NODE_NAME).pos
-}
+export const getThisPageNodePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
+    return getParentNodePosOfType(doc, pos, PAGE_NODE_NAME).pos;
+};
 
 /**
  * Get the paragraph node position.
@@ -86,12 +73,9 @@ export const getThisPageNodePosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The position of the paragraph node.
  */
-export const getThisParagraphNodePosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): number => {
-  return getParentNodePosOfType(doc, pos, 'paragraph').pos
-}
+export const getThisParagraphNodePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
+    return getParentNodePosOfType(doc, pos, "paragraph").pos;
+};
 
 /**
  * Get the page node position and the page node itself.
@@ -99,23 +83,20 @@ export const getThisParagraphNodePosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {pagePos: number, pageNode: Node} The position and the node of the page.
  */
-export const getPageNodeAndPosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): { pagePos: number; pageNode: Nullable<PMNode> } => {
-  if (typeof pos === 'number') {
-    return getPageNodeAndPosition(doc, doc.resolve(pos))
-  }
+export const getPageNodeAndPosition = (doc: PMNode, pos: ResolvedPos | number): { pagePos: number; pageNode: Nullable<PMNode> } => {
+    if (typeof pos === "number") {
+        return getPageNodeAndPosition(doc, doc.resolve(pos));
+    }
 
-  const pagePos = getThisPageNodePosition(doc, pos)
-  const pageNode = doc.nodeAt(pagePos)
-  if (!isPageNode(pageNode)) {
-    console.warn('No page node found')
-    return { pagePos: -1, pageNode }
-  }
+    const pagePos = getThisPageNodePosition(doc, pos);
+    const pageNode = doc.nodeAt(pagePos);
+    if (!isPageNode(pageNode)) {
+        console.warn("No page node found");
+        return { pagePos: -1, pageNode };
+    }
 
-  return { pagePos, pageNode }
-}
+    return { pagePos, pageNode };
+};
 
 /**
  * Get the paragraph node position and the paragraph node itself.
@@ -124,38 +105,32 @@ export const getPageNodeAndPosition = (
  * @returns {paragraphPos: number, paragraphNode: Node} The position and the node of the paragraph.
  */
 export const getParagraphNodeAndPosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
+    doc: PMNode,
+    pos: ResolvedPos | number
 ): { paragraphPos: number; paragraphNode: Nullable<PMNode> } => {
-  if (typeof pos === 'number') {
-    return getParagraphNodeAndPosition(doc, doc.resolve(pos))
-  }
+    if (typeof pos === "number") {
+        return getParagraphNodeAndPosition(doc, doc.resolve(pos));
+    }
 
-  if (isPosAtStartOfDocument(doc, pos, false)) {
-    // Find the next paragraph node
-    const { nextParagraphPos, nextParagraphNode } = getNextParagraph(
-      doc,
-      pos.pos,
-    )
-    return { paragraphPos: nextParagraphPos, paragraphNode: nextParagraphNode }
-  } else if (isPosAtEndOfDocument(doc, pos)) {
-    // Find the previous paragraph node
-    const { prevParagraphPos, prevParagraphNode } = getPreviousParagraph(
-      doc,
-      pos.pos,
-    )
-    return { paragraphPos: prevParagraphPos, paragraphNode: prevParagraphNode }
-  }
+    if (isPosAtStartOfDocument(doc, pos, false)) {
+        // Find the next paragraph node
+        const { nextParagraphPos, nextParagraphNode } = getNextParagraph(doc, pos.pos);
+        return { paragraphPos: nextParagraphPos, paragraphNode: nextParagraphNode };
+    } else if (isPosAtEndOfDocument(doc, pos)) {
+        // Find the previous paragraph node
+        const { prevParagraphPos, prevParagraphNode } = getPreviousParagraph(doc, pos.pos);
+        return { paragraphPos: prevParagraphPos, paragraphNode: prevParagraphNode };
+    }
 
-  const paragraphPos = getThisParagraphNodePosition(doc, pos)
-  const paragraphNode = doc.nodeAt(paragraphPos)
-  if (!isParagraphNode(paragraphNode)) {
-    console.warn('No paragraph node found')
-    return { paragraphPos: -1, paragraphNode }
-  }
+    const paragraphPos = getThisParagraphNodePosition(doc, pos);
+    const paragraphNode = doc.nodeAt(paragraphPos);
+    if (!isParagraphNode(paragraphNode)) {
+        console.warn("No paragraph node found");
+        return { paragraphPos: -1, paragraphNode };
+    }
 
-  return { paragraphPos, paragraphNode }
-}
+    return { paragraphPos, paragraphNode };
+};
 
 /**
  * Get the start of the page position.
@@ -163,18 +138,15 @@ export const getParagraphNodeAndPosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The start position of the page.
  */
-export const getStartOfPagePosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): number => {
-  if (typeof pos === 'number') {
-    return getStartOfPagePosition(doc, doc.resolve(pos))
-  }
+export const getStartOfPagePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
+    if (typeof pos === "number") {
+        return getStartOfPagePosition(doc, doc.resolve(pos));
+    }
 
-  const { pagePos } = getPageNodeAndPosition(doc, pos)
+    const { pagePos } = getPageNodeAndPosition(doc, pos);
 
-  return pagePos
-}
+    return pagePos;
+};
 
 /**
  * Get the start of the paragraph position.
@@ -182,17 +154,14 @@ export const getStartOfPagePosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The start position of the paragraph.
  */
-export const getStartOfParagraphPosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): number => {
-  if (typeof pos === 'number') {
-    return getStartOfParagraphPosition(doc, doc.resolve(pos))
-  }
+export const getStartOfParagraphPosition = (doc: PMNode, pos: ResolvedPos | number): number => {
+    if (typeof pos === "number") {
+        return getStartOfParagraphPosition(doc, doc.resolve(pos));
+    }
 
-  const { paragraphPos } = getParagraphNodeAndPosition(doc, pos)
-  return paragraphPos
-}
+    const { paragraphPos } = getParagraphNodeAndPosition(doc, pos);
+    return paragraphPos;
+};
 
 /**
  * Get the start of the page and paragraph positions.
@@ -201,14 +170,14 @@ export const getStartOfParagraphPosition = (
  * @returns {startOfPagePos: number, startOfParagraphPos: number} The start positions of the page and paragraph.
  */
 export const getStartOfPageAndParagraphPosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
+    doc: PMNode,
+    pos: ResolvedPos | number
 ): { startOfPagePos: number; startOfParagraphPos: number } => {
-  const startOfParagraphPos = getStartOfParagraphPosition(doc, pos)
-  const startOfPagePos = getStartOfPagePosition(doc, pos)
+    const startOfParagraphPos = getStartOfParagraphPosition(doc, pos);
+    const startOfPagePos = getStartOfPagePosition(doc, pos);
 
-  return { startOfPagePos, startOfParagraphPos }
-}
+    return { startOfPagePos, startOfParagraphPos };
+};
 
 /**
  * Get the end of the page position.
@@ -216,43 +185,37 @@ export const getStartOfPageAndParagraphPosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The end position of the page.
  */
-export const getEndOfPagePosition = (
-  doc: PMNode,
-  pos: ResolvedPos | number,
-): number => {
-  if (typeof pos === 'number') {
-    return getEndOfPagePosition(doc, doc.resolve(pos))
-  }
+export const getEndOfPagePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
+    if (typeof pos === "number") {
+        return getEndOfPagePosition(doc, doc.resolve(pos));
+    }
 
-  const { pagePos, pageNode } = getPageNodeAndPosition(doc, pos)
-  if (!pageNode) {
-    return pagePos
-  }
+    const { pagePos, pageNode } = getPageNodeAndPosition(doc, pos);
+    if (!pageNode) {
+        return pagePos;
+    }
 
-  return pagePos + pageNode.content.size
-}
+    return pagePos + pageNode.content.size;
+};
 
 /**
  * Get the end of the paragraph position.
  * @param doc - The document node.
- * @param $pos - The resolved position in the document or the absolute position of the node.
+ * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The end position of the paragraph.
  */
-export const getEndOfParagraphPosition = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): number => {
-  if (typeof $pos === 'number') {
-    return getEndOfParagraphPosition(doc, doc.resolve($pos))
-  }
+export const getEndOfParagraphPosition = (doc: PMNode, $pos: ResolvedPos | number): number => {
+    if (typeof $pos === "number") {
+        return getEndOfParagraphPosition(doc, doc.resolve($pos));
+    }
 
-  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
-  if (!paragraphNode) {
-    return paragraphPos
-  }
+    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
+    if (!paragraphNode) {
+        return paragraphPos;
+    }
 
-  return paragraphPos + paragraphNode.content.size
-}
+    return paragraphPos + paragraphNode.content.size;
+};
 
 /**
  * Get the end of the page and paragraph positions.
@@ -261,79 +224,70 @@ export const getEndOfParagraphPosition = (
  * @returns {endOfPagePos: number, endOfParagraphPos: number} The end positions of the page and paragraph.
  */
 export const getEndOfPageAndParagraphPosition = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
+    doc: PMNode,
+    $pos: ResolvedPos | number
 ): { endOfPagePos: number; endOfParagraphPos: number } => {
-  const endOfParagraphPos = getEndOfParagraphPosition(doc, $pos)
-  const endOfPagePos = getEndOfPagePosition(doc, $pos)
+    const endOfParagraphPos = getEndOfParagraphPosition(doc, $pos);
+    const endOfPagePos = getEndOfPagePosition(doc, $pos);
 
-  return { endOfPagePos, endOfParagraphPos }
-}
+    return { endOfPagePos, endOfParagraphPos };
+};
 
 /**
  * Check if the given position is at the start of the document.
  * @param state - The current editor state.
  * @returns True if text is currently highlighted, false otherwise.
  */
-const isPosMatchingStartOfPageCondition = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-  checkExactStart: boolean,
-): boolean => {
-  // Resolve position if given as a number
-  if (typeof $pos === 'number') {
-    return isPosMatchingStartOfPageCondition(
-      doc,
-      doc.resolve($pos),
-      checkExactStart,
-    )
-  }
-
-  // Check if we are at the start of the document
-  if (isPosAtStartOfDocument(doc, $pos, false)) {
-    return true
-  }
-
-  // Ensure that the position is within a valid block (paragraph)
-  if (!isPositionWithinParagraph($pos)) {
-    return false
-  }
-
-  // Get positions for paragraph and page
-  const { startOfPagePos, startOfParagraphPos } =
-    getStartOfPageAndParagraphPosition(doc, $pos)
-  if (startOfPagePos < 0) {
-    console.warn('Invalid page position')
-    return false
-  }
-
-  if (startOfParagraphPos < 0) {
-    console.warn('Invalid paragraph position')
-    return false
-  }
-
-  // Determine the condition to check
-  const isFirstParagraph = startOfPagePos + 1 === startOfParagraphPos
-  if (checkExactStart) {
-    // Check if position is exactly at the start of the page
-    // First position of page will always be 1 more than the paragraph position
-    const isPosAtStartOfParagraph = $pos.pos - 1 === startOfParagraphPos
-    if (isFirstParagraph && isPosAtStartOfParagraph) {
-      console.log('At the start of the page')
-      return true
+const isPosMatchingStartOfPageCondition = (doc: PMNode, $pos: ResolvedPos | number, checkExactStart: boolean): boolean => {
+    // Resolve position if given as a number
+    if (typeof $pos === "number") {
+        return isPosMatchingStartOfPageCondition(doc, doc.resolve($pos), checkExactStart);
     }
-    console.log('Not at the start of the page')
-    return false
-  } else {
-    // Check if position is at the first child of the page
-    if (isFirstParagraph) {
-      console.log('In the first child of the page')
-      return true
+
+    // Check if we are at the start of the document
+    if (isPosAtStartOfDocument(doc, $pos, false)) {
+        return true;
     }
-    console.log('Not in the first child of the page')
-    return false
-  }
-}
+
+    // Ensure that the position is within a valid block (paragraph)
+    if (!isPositionWithinParagraph($pos)) {
+        return false;
+    }
+
+    // Get positions for paragraph and page
+    const { startOfPagePos, startOfParagraphPos } = getStartOfPageAndParagraphPosition(doc, $pos);
+    if (startOfPagePos < 0) {
+        console.warn("Invalid page position");
+        return false;
+    }
+
+    if (startOfParagraphPos < 0) {
+        console.warn("Invalid paragraph position");
+        return false;
+    }
+
+    // Determine the condition to check
+    const isFirstParagraph = startOfPagePos + 1 === startOfParagraphPos;
+    if (checkExactStart) {
+        // Check if position is exactly at the start of the page
+        // First position of page will always be 1 more than the paragraph position
+        const isPosAtStartOfParagraph = $pos.pos - 1 === startOfParagraphPos;
+        if (isFirstParagraph && isPosAtStartOfParagraph) {
+            console.log("At the start of the page");
+            return true;
+        }
+        console.log("Not at the start of the page");
+        return false;
+    } else {
+        // Check if position is at the first child of the page
+        if (isFirstParagraph) {
+            console.log("In the first child of the page");
+            return true;
+        }
+        console.log("Not in the first child of the page");
+        return false;
+    }
+};
 
 /**
  * Check if the given position is at the start of the page or the first child of the page.
@@ -341,12 +295,9 @@ const isPosMatchingStartOfPageCondition = (
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the condition is met, false otherwise.
  */
-export const isPosAtStartOfPage = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  return isPosMatchingStartOfPageCondition(doc, $pos, true)
-}
+export const isPosAtStartOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    return isPosMatchingStartOfPageCondition(doc, $pos, true);
+};
 
 /**
  * Check if the given position is at the first paragraph child of the page.
@@ -354,12 +305,9 @@ export const isPosAtStartOfPage = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the start of the page, false otherwise.
  */
-export const isPosAtFirstChildOfPage = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  return isPosMatchingStartOfPageCondition(doc, $pos, false)
-}
+export const isPosAtFirstChildOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    return isPosMatchingStartOfPageCondition(doc, $pos, false);
+};
 
 /**
  * Check if the given position is at the end of the page or the last child of the page.
@@ -368,64 +316,53 @@ export const isPosAtFirstChildOfPage = (
  * @param checkExactEnd - Whether to check for the exact end of the page (true) or the last child of the page (false).
  * @returns {boolean} True if the condition is met, false otherwise.
  */
-const isPosMatchingEndOfPageCondition = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-  checkExactEnd: boolean,
-): boolean => {
-  // Resolve position if given as a number
-  if (typeof $pos === 'number') {
-    return isPosMatchingEndOfPageCondition(
-      doc,
-      doc.resolve($pos),
-      checkExactEnd,
-    )
-  }
-
-  // Check if we are at the end of the document
-  if (isPosAtEndOfDocument(doc, $pos)) {
-    return true
-  }
-
-  // Ensure that the position is within a valid block (paragraph)
-  if (!isPositionWithinParagraph($pos)) {
-    return false
-  }
-
-  // Get positions for paragraph and page
-  const { endOfParagraphPos, endOfPagePos } = getEndOfPageAndParagraphPosition(
-    doc,
-    $pos,
-  )
-  if (endOfParagraphPos < 0) {
-    console.warn('Invalid end of paragraph position')
-    return false
-  }
-
-  if (endOfPagePos < 0) {
-    console.warn('Invalid end of page position')
-    return false
-  }
-
-  // Determine the condition to check
-  if (checkExactEnd) {
-    // Check if position is exactly at the end of the page
-    if ($pos.pos === endOfPagePos) {
-      console.log('At the end of the page')
-      return true
+const isPosMatchingEndOfPageCondition = (doc: PMNode, $pos: ResolvedPos | number, checkExactEnd: boolean): boolean => {
+    // Resolve position if given as a number
+    if (typeof $pos === "number") {
+        return isPosMatchingEndOfPageCondition(doc, doc.resolve($pos), checkExactEnd);
     }
-    console.log('Not at the end of the page')
-    return false
-  } else {
-    // Check if position is at the last child of the page
-    if (endOfParagraphPos + 1 === endOfPagePos) {
-      console.log('In the last child of the page')
-      return true
+
+    // Check if we are at the end of the document
+    if (isPosAtEndOfDocument(doc, $pos)) {
+        return true;
     }
-    console.log('Not in the last child of the page')
-    return false
-  }
-}
+
+    // Ensure that the position is within a valid block (paragraph)
+    if (!isPositionWithinParagraph($pos)) {
+        return false;
+    }
+
+    // Get positions for paragraph and page
+    const { endOfParagraphPos, endOfPagePos } = getEndOfPageAndParagraphPosition(doc, $pos);
+    if (endOfParagraphPos < 0) {
+        console.warn("Invalid end of paragraph position");
+        return false;
+    }
+
+    if (endOfPagePos < 0) {
+        console.warn("Invalid end of page position");
+        return false;
+    }
+
+    // Determine the condition to check
+    if (checkExactEnd) {
+        // Check if position is exactly at the end of the page
+        if ($pos.pos === endOfPagePos) {
+            console.log("At the end of the page");
+            return true;
+        }
+        console.log("Not at the end of the page");
+        return false;
+    } else {
+        // Check if position is at the last child of the page
+        if (endOfParagraphPos + 1 === endOfPagePos) {
+            console.log("In the last child of the page");
+            return true;
+        }
+        console.log("Not in the last child of the page");
+        return false;
+    }
+};
 
 /**
  * Check if the given position is exactly at the end of the page.
@@ -433,12 +370,9 @@ const isPosMatchingEndOfPageCondition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the page, false otherwise.
  */
-export const isPosAtEndOfPage = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  return isPosMatchingEndOfPageCondition(doc, $pos, true)
-}
+export const isPosAtEndOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    return isPosMatchingEndOfPageCondition(doc, $pos, true);
+};
 
 /**
  * Check if the given position is at the last paragraph child of the page.
@@ -446,12 +380,9 @@ export const isPosAtEndOfPage = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the page, false otherwise.
  */
-export const isPosAtLastChildOfPage = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  return isPosMatchingEndOfPageCondition(doc, $pos, false)
-}
+export const isPosAtLastChildOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    return isPosMatchingEndOfPageCondition(doc, $pos, false);
+};
 
 /**
  * Check if the given position is at the start of the document.
@@ -459,19 +390,15 @@ export const isPosAtLastChildOfPage = (
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the start of the document, false otherwise.
  */
-export const isPosAtStartOfDocument = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-  allowTextBlock: boolean,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isPosAtStartOfDocument(doc, doc.resolve($pos), allowTextBlock)
-  }
+export const isPosAtStartOfDocument = (doc: PMNode, $pos: ResolvedPos | number, allowTextBlock: boolean): boolean => {
+    if (typeof $pos === "number") {
+        return isPosAtStartOfDocument(doc, doc.resolve($pos), allowTextBlock);
+    }
 
-  const maxPos = allowTextBlock ? 2 : 1
+    const maxPos = allowTextBlock ? 2 : 1;
 
-  return $pos.pos <= maxPos
-}
+    return $pos.pos <= maxPos;
+};
 
 /**
  * Check if the given position is at the end of the document.
@@ -479,16 +406,13 @@ export const isPosAtStartOfDocument = (
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the document, false otherwise.
  */
-export const isPosAtEndOfDocument = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isPosAtEndOfDocument(doc, doc.resolve($pos))
-  }
+export const isPosAtEndOfDocument = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    if (typeof $pos === "number") {
+        return isPosAtEndOfDocument(doc, doc.resolve($pos));
+    }
 
-  return $pos.pos >= doc.nodeSize - 2
-}
+    return $pos.pos >= doc.nodeSize - 2;
+};
 
 /**
  * Get the previous paragraph node.
@@ -496,31 +420,28 @@ export const isPosAtEndOfDocument = (
  * @param pos - The position in the document.
  * @returns {PMNode} The previous paragraph node.
  */
-export const getPreviousParagraph = (
-  doc: PMNode,
-  pos: number,
-): { prevParagraphPos: number; prevParagraphNode: Nullable<PMNode> } => {
-  let prevParagraphPos = pos
-  let prevParagraphNode = null
-  while (prevParagraphNode === null && prevParagraphPos > 0) {
-    prevParagraphPos -= 1
-    const node = doc.nodeAt(prevParagraphPos)
-    if (!node) {
-      continue
+export const getPreviousParagraph = (doc: PMNode, pos: number): { prevParagraphPos: number; prevParagraphNode: Nullable<PMNode> } => {
+    let prevParagraphPos = pos;
+    let prevParagraphNode = null;
+    while (prevParagraphNode === null && prevParagraphPos > 0) {
+        prevParagraphPos -= 1;
+        const node = doc.nodeAt(prevParagraphPos);
+        if (!node) {
+            continue;
+        }
+
+        if (isParagraphNode(node)) {
+            prevParagraphNode = node;
+            prevParagraphPos = prevParagraphPos;
+        }
     }
 
-    if (isParagraphNode(node)) {
-      prevParagraphNode = node
-      prevParagraphPos = prevParagraphPos
+    if (!prevParagraphNode) {
+        prevParagraphPos = -1;
     }
-  }
 
-  if (!prevParagraphNode) {
-    prevParagraphPos = -1
-  }
-
-  return { prevParagraphPos, prevParagraphNode }
-}
+    return { prevParagraphPos, prevParagraphNode };
+};
 
 /**
  * Get the next paragraph node.
@@ -528,32 +449,29 @@ export const getPreviousParagraph = (
  * @param pos - The position in the document.
  * @returns {PMNode} The next paragraph node.
  */
-export const getNextParagraph = (
-  doc: PMNode,
-  pos: number,
-): { nextParagraphPos: number; nextParagraphNode: Nullable<PMNode> } => {
-  const documentLength = doc.content.size
-  let nextParagraphPos = pos
-  let nextParagraphNode = null
-  while (nextParagraphNode === null && nextParagraphPos < documentLength) {
-    nextParagraphPos += 1
-    const node = doc.nodeAt(nextParagraphPos)
-    if (!node) {
-      continue
+export const getNextParagraph = (doc: PMNode, pos: number): { nextParagraphPos: number; nextParagraphNode: Nullable<PMNode> } => {
+    const documentLength = doc.content.size;
+    let nextParagraphPos = pos;
+    let nextParagraphNode = null;
+    while (nextParagraphNode === null && nextParagraphPos < documentLength) {
+        nextParagraphPos += 1;
+        const node = doc.nodeAt(nextParagraphPos);
+        if (!node) {
+            continue;
+        }
+
+        if (isParagraphNode(node)) {
+            nextParagraphNode = node;
+            nextParagraphPos = nextParagraphPos;
+        }
     }
 
-    if (isParagraphNode(node)) {
-      nextParagraphNode = node
-      nextParagraphPos = nextParagraphPos
+    if (!nextParagraphNode) {
+        nextParagraphPos = -1;
     }
-  }
 
-  if (!nextParagraphNode) {
-    nextParagraphPos = -1
-  }
-
-  return { nextParagraphPos, nextParagraphNode }
-}
+    return { nextParagraphPos, nextParagraphNode };
+};
 
 /**
  * Determine if the resolved position is at the start of a paragraph node.
@@ -561,22 +479,19 @@ export const getNextParagraph = (
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the start of a paragraph node, false otherwise.
  */
-export const isAtStartOfParagraph = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isAtStartOfParagraph(doc, doc.resolve($pos))
-  }
+export const isAtStartOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    if (typeof $pos === "number") {
+        return isAtStartOfParagraph(doc, doc.resolve($pos));
+    }
 
-  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
-  if (!paragraphNode) {
-    return false
-  }
+    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
+    if (!paragraphNode) {
+        return false;
+    }
 
-  // We allow for the cursor to be at the start of the paragraph node or the start of the first text child node.
-  return inRange($pos.pos, paragraphPos, paragraphPos + 1)
-}
+    // We allow for the cursor to be at the start of the paragraph node or the start of the first text child node.
+    return inRange($pos.pos, paragraphPos, paragraphPos + 1);
+};
 
 /**
  * Determine if the resolved position is at the end of a paragraph node.
@@ -584,21 +499,18 @@ export const isAtStartOfParagraph = (
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the end of a paragraph node, false otherwise.
  */
-export const isAtEndOfParagraph = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isAtEndOfParagraph(doc, doc.resolve($pos))
-  }
+export const isAtEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    if (typeof $pos === "number") {
+        return isAtEndOfParagraph(doc, doc.resolve($pos));
+    }
 
-  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
-  if (!paragraphNode) {
-    return false
-  }
+    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
+    if (!paragraphNode) {
+        return false;
+    }
 
-  return $pos.pos + 1 === paragraphPos + paragraphNode.nodeSize
-}
+    return $pos.pos + 1 === paragraphPos + paragraphNode.nodeSize;
+};
 
 /**
  * Determine if the resolved position is at the start or end of a paragraph node.
@@ -606,12 +518,9 @@ export const isAtEndOfParagraph = (
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the start or end of a paragraph node, false otherwise.
  */
-export const isAtStartOrEndOfParagraph = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  return isAtStartOfParagraph(doc, $pos) || isAtEndOfParagraph(doc, $pos)
-}
+export const isAtStartOrEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    return isAtStartOfParagraph(doc, $pos) || isAtEndOfParagraph(doc, $pos);
+};
 
 /**
  * Determine if the previous paragraph is empty.
@@ -619,21 +528,18 @@ export const isAtStartOrEndOfParagraph = (
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the previous paragraph is empty or does not exist, false otherwise.
  */
-export const isPreviousParagraphEmpty = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isPreviousParagraphEmpty(doc, doc.resolve($pos))
-  }
+export const isPreviousParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    if (typeof $pos === "number") {
+        return isPreviousParagraphEmpty(doc, doc.resolve($pos));
+    }
 
-  const { prevParagraphNode } = getPreviousParagraph(doc, $pos.pos)
-  if (!prevParagraphNode) {
-    return false
-  }
+    const { prevParagraphNode } = getPreviousParagraph(doc, $pos.pos);
+    if (!prevParagraphNode) {
+        return false;
+    }
 
-  return isNodeEmpty(prevParagraphNode)
-}
+    return isNodeEmpty(prevParagraphNode);
+};
 
 /**
  * Determine if the next paragraph is empty.
@@ -641,21 +547,18 @@ export const isPreviousParagraphEmpty = (
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the next paragraph is empty or does not exist, false otherwise.
  */
-export const isNextParagraphEmpty = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-): boolean => {
-  if (typeof $pos === 'number') {
-    return isNextParagraphEmpty(doc, doc.resolve($pos))
-  }
+export const isNextParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
+    if (typeof $pos === "number") {
+        return isNextParagraphEmpty(doc, doc.resolve($pos));
+    }
 
-  const { nextParagraphNode } = getNextParagraph(doc, $pos.pos)
-  if (!nextParagraphNode) {
-    return false
-  }
+    const { nextParagraphNode } = getNextParagraph(doc, $pos.pos);
+    if (!nextParagraphNode) {
+        return false;
+    }
 
-  return isNodeEmpty(nextParagraphNode)
-}
+    return isNodeEmpty(nextParagraphNode);
+};
 
 /**
  * Get the page number of the resolved position.
@@ -664,25 +567,21 @@ export const isNextParagraphEmpty = (
  * @param zeroIndexed - Whether to return the page number as zero-indexed. Default is true.
  * @returns {number} The page number of the resolved position.
  */
-export const getPageNumber = (
-  doc: PMNode,
-  $pos: ResolvedPos | number,
-  zeroIndexed = true,
-): number => {
-  if (typeof $pos === 'number') {
-    return getPageNumber(doc, doc.resolve($pos))
-  }
+export const getPageNumber = (doc: PMNode, $pos: ResolvedPos | number, zeroIndexed: boolean = true): number => {
+    if (typeof $pos === "number") {
+        return getPageNumber(doc, doc.resolve($pos));
+    }
 
-  const { pagePos } = getPageNodeAndPosition(doc, $pos)
-  if (pagePos < 0) {
-    console.log('Unable to find page node')
-    return -1
-  }
+    const { pagePos } = getPageNodeAndPosition(doc, $pos);
+    if (pagePos < 0) {
+        console.log("Unable to find page node");
+        return -1;
+    }
 
-  const pageNodes = collectPageNodes(doc)
-  const pageNode = pageNodes.findIndex((node) => node.pos === pagePos)
-  return pageNode + (zeroIndexed ? 0 : 1)
-}
+    const pageNodes = collectPageNodes(doc);
+    const pageNode = pageNodes.findIndex((node) => node.pos === pagePos);
+    return pageNode + (zeroIndexed ? 0 : 1);
+};
 
 /**
  * Collect content nodes and their old positions
@@ -690,22 +589,22 @@ export const getPageNumber = (
  * @returns {NodePosArray} The content nodes and their positions.
  */
 export const collectContentNodes = (state: EditorState): NodePosArray => {
-  const { schema } = state
-  const pageType = schema.nodes.page
+    const { schema } = state;
+    const pageType = schema.nodes.page;
 
-  const contentNodes: NodePosArray = []
-  state.doc.forEach((node, offset) => {
-    if (node.type === pageType) {
-      node.forEach((child, childOffset) => {
-        contentNodes.push({ node: child, pos: offset + childOffset + 1 })
-      })
-    } else {
-      contentNodes.push({ node, pos: offset + 1 })
-    }
-  })
+    const contentNodes: NodePosArray = [];
+    state.doc.forEach((node, offset) => {
+        if (node.type === pageType) {
+            node.forEach((child, childOffset) => {
+                contentNodes.push({ node: child, pos: offset + childOffset + 1 });
+            });
+        } else {
+            contentNodes.push({ node, pos: offset + 1 });
+        }
+    });
 
-  return contentNodes
-}
+    return contentNodes;
+};
 
 /**
  * Calculates the margins of the element.
@@ -713,14 +612,14 @@ export const collectContentNodes = (state: EditorState): NodePosArray => {
  * @returns {MarginConfig} The margins of the element.
  */
 const calculateElementMargins = (element: HTMLElement): MarginConfig => {
-  const style = window.getComputedStyle(element)
-  return {
-    top: parseFloat(style.marginTop),
-    right: parseFloat(style.marginRight),
-    bottom: parseFloat(style.marginBottom),
-    left: parseFloat(style.marginLeft),
-  }
-}
+    const style = window.getComputedStyle(element);
+    return {
+        top: parseFloat(style.marginTop),
+        right: parseFloat(style.marginRight),
+        bottom: parseFloat(style.marginBottom),
+        left: parseFloat(style.marginLeft),
+    };
+};
 
 /**
  * Measure the heights of the content nodes.
@@ -728,35 +627,32 @@ const calculateElementMargins = (element: HTMLElement): MarginConfig => {
  * @param contentNodes - The content nodes and their positions.
  * @returns {number[]} The heights of the content nodes.
  */
-export const measureNodeHeights = (
-  view: EditorView,
-  contentNodes: NodePosArray,
-): number[] => {
-  const paragraphType = view.state.schema.nodes.paragraph
+export const measureNodeHeights = (view: EditorView, contentNodes: NodePosArray): number[] => {
+    const paragraphType = view.state.schema.nodes.paragraph;
 
-  const nodeHeights = contentNodes.map(({ pos, node }) => {
-    const domNode = view.nodeDOM(pos)
-    if (domNode instanceof HTMLElement) {
-      let { height } = domNode.getBoundingClientRect()
+    const nodeHeights = contentNodes.map(({ pos, node }) => {
+        const domNode = view.nodeDOM(pos);
+        if (domNode instanceof HTMLElement) {
+            let { height } = domNode.getBoundingClientRect();
 
-      const { top: marginTop } = calculateElementMargins(domNode)
+            const { top: marginTop } = calculateElementMargins(domNode);
 
-      if (height === 0) {
-        if (node.type === paragraphType || node.isTextblock) {
-          // Assign a minimum height to empty paragraphs or textblocks
-          height = MIN_PARAGRAPH_HEIGHT
+            if (height === 0) {
+                if (node.type === paragraphType || node.isTextblock) {
+                    // Assign a minimum height to empty paragraphs or textblocks
+                    height = MIN_PARAGRAPH_HEIGHT;
+                }
+            }
+
+            // We use top margin only because there is overlap of margins between paragraphs
+            return height + marginTop;
         }
-      }
 
-      // We use top margin only because there is overlap of margins between paragraphs
-      return height + marginTop
-    }
+        return MIN_PARAGRAPH_HEIGHT; // Default to minimum height if DOM element is not found
+    });
 
-    return MIN_PARAGRAPH_HEIGHT // Default to minimum height if DOM element is not found
-  })
-
-  return nodeHeights
-}
+    return nodeHeights;
+};
 
 /**
  * Build the new document and keep track of new positions
@@ -766,188 +662,184 @@ export const measureNodeHeights = (
  * @returns {newDoc: PMNode, oldToNewPosMap: CursorMap} The new document and the mapping from old positions to new positions.
  */
 export const buildNewDocument = (
-  state: EditorState,
-  contentNodes: NodePosArray,
-  nodeHeights: number[],
-  view: EditorView,
+    state: EditorState,
+    contentNodes: NodePosArray,
+    nodeHeights: number[],
+    view: EditorView,
 ): { newDoc: PMNode; oldToNewPosMap: CursorMap } => {
-  const { schema, doc } = state
-  let pageNum = 0
+    const { schema, doc } = state;
+    let pageNum = 0;
 
-  const pageType = schema.nodes.page
-  const pages: PMNode[] = []
-  let { pageNodeAttributes, pagePixelDimensions } =
-    getCalculatedPageNodeAttributes(state, pageNum)
+    const pageType = schema.nodes.page;
+    const pages: PMNode[] = [];
+    let { pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum);
 
-  const addPage = (currentPageContent: PMNode[]): PMNode => {
-    const pageNode = pageType.create(pageNodeAttributes, currentPageContent)
-    pages.push(pageNode)
-    return pageNode
-  }
+    const addPage = (currentPageContent: PMNode[]): PMNode => {
+        const pageNode = pageType.create(pageNodeAttributes, currentPageContent);
+        pages.push(pageNode);
+        return pageNode;
+    };
 
-  let currentPageContent: PMNode[] = []
-  let currentHeight = 0
+    let currentPageContent: PMNode[] = [];
+    let currentHeight = 0;
 
-  const oldToNewPosMap: CursorMap = new Map<number, number>()
-  let cumulativeNewDocPos = 1
-  const tableHandler = TableHandler.getInstance()
-  for (let i = 0; i < contentNodes.length; i++) {
-    const { node, pos: oldPos } = contentNodes[i]
-    const nodeHeight = nodeHeights[i]
+    const oldToNewPosMap: CursorMap = new Map<number, number>();
+    let cumulativeNewDocPos = 1;
+    const tableHandler = TableHandler.getInstance()
+    for (let i = 0; i < contentNodes.length; i++) {
+        const { node, pos: oldPos } = contentNodes[i];
+        const nodeHeight = nodeHeights[i];
 
-    const isPageFull =
-      currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight &&
-      currentPageContent.length > 0
+        const isPageFull = currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight && currentPageContent.length > 0;
+        const isTable = node.type.name === 'table'
+        if (isTable) {
+          /**
+           * LOGIC
+           * if no groupId, measure the table and split based on either available height or pageContentHeight
+           * if already split
+           *  - gather tables
+           *  - for each table check against available height or max height
+           *  - if overflows, move rows to the next table (if not exist, create)
+           *  - if underflows, check if rows from next table can be moved to this table
+           *
+           */
+          let tables: PMNode[] = [],
+            measurements: TableMeasurement[] = []
+          const availableHeight =
+            pagePixelDimensions.pageContentHeight - currentHeight
+          const oldPoses: number[] = []
+          if (!node.attrs.groupId) {
+            const measurement = tableHandler.measureTable(node, oldPos, view)
 
-    const isTable = node.type.name === 'table'
-    if (isTable) {
-      /**
-       * LOGIC
-       * if no groupId, measure the table and split based on either available height or pageContentHeight
-       * if already split
-       *  - gather tables
-       *  - for each table check against available height or max height
-       *  - if overflows, move rows to the next table (if not exist, create)
-       *  - if underflows, check if rows from next table can be moved to this table
-       *
-       */
-      let tables: PMNode[] = [],
-        measurements: TableMeasurement[] = []
-      const availableHeight =
-        pagePixelDimensions.pageContentHeight - currentHeight
-      const oldPoses: number[] = []
-      if (!node.attrs.groupId) {
-        const measurement = tableHandler.measureTable(node, oldPos, view)
+            if (isPageFull) {
+              // this has already checked whether the node fits
+              const {
+                tables: optimisedTables,
+                measurements: optimisedMeasurements,
+              } = tableHandler.splitTableAtHeight(
+                node,
+                availableHeight,
+                measurement,
+                schema,
+                pagePixelDimensions.pageContentHeight,
+              )
+              tables = optimisedTables.filter((table) =>
+                table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
+              )
+              measurements = optimisedMeasurements.slice(0, tables.length)
+            }
+          } else {
+            const groupTables = contentNodes.filter(
+              (n) =>
+                n.node.type.name === 'table' &&
+                n.node.attrs.groupId === node.attrs.groupId,
+            )
+            const groupMeasurements = groupTables.map((t) =>
+              tableHandler.measureTable(t.node, t.pos, view),
+            )
+            groupTables.forEach((t, i) => {
+              // Store absolute position without adjustments
+              oldPoses.push(t.pos)
+            })
+            const { tables: optimisedTables, measurements: optimisedMeasurements } =
+              tableHandler.optimiseTables(
+                groupTables.map((t) => t.node),
+                groupMeasurements,
+                schema,
+                availableHeight,
+                pagePixelDimensions.pageContentHeight,
+              )
+            tables = optimisedTables.filter((table) =>
+              table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
+            )
+            measurements = optimisedMeasurements.slice(0, tables.length)
+            i += groupTables.length
+          }
 
-        if (isPageFull) {
-          // this has already checked whether the node fits
-          const {
-            tables: optimisedTables,
-            measurements: optimisedMeasurements,
-          } = tableHandler.splitTableAtHeight(
-            node,
-            availableHeight,
-            measurement,
-            schema,
-            pagePixelDimensions.pageContentHeight,
-          )
-          tables = optimisedTables.filter((table) =>
-            table && table.type && table.type.name === 'table' && table.content && table.content.content.length > 0
-          )
-          measurements = optimisedMeasurements.slice(0, tables.length)
+          tables.forEach((table, index) => {
+            if (!table || !table.type || table.type.name !== 'table' || !table.content) {
+              console.warn('Invalid table encountered during pagination')
+              return
+            }
+            // insert current if the first entry exceeds height
+            if (index === 0 && measurements[index].totalHeight > availableHeight) {
+              if (oldPoses[index]) {
+                // Calculate position based on current page content plus the table's position within the page
+                const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
+                oldToNewPosMap.set(oldPoses[index], basePos)
+              }
+              const pageNode = addPage(currentPageContent)
+              cumulativeNewDocPos += pageNode.nodeSize
+              currentPageContent = []
+              currentHeight = 0
+              pageNum++
+              if (isPageNumInRange(doc, pageNum)) {
+                ;({ pageNodeAttributes, pagePixelDimensions } =
+                  getCalculatedPageNodeAttributes(state, pageNum))
+              }
+            }
+            if (index < tables.length - 1) {
+              currentPageContent.push(table)
+              if (oldPoses[index]) {
+                // For tables at page boundaries, use cumulative position
+                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
+                oldToNewPosMap.set(oldPoses[index], basePos)
+              }
+              const pageNode = addPage(currentPageContent)
+              cumulativeNewDocPos += pageNode.nodeSize
+              currentPageContent = []
+              currentHeight = 0
+              pageNum++
+              if (isPageNumInRange(doc, pageNum)) {
+                ;({ pageNodeAttributes, pagePixelDimensions } =
+                  getCalculatedPageNodeAttributes(state, pageNum))
+              }
+            } else {
+              currentPageContent.push(table)
+              currentHeight += measurements[index].totalHeight
+
+              if (oldPoses[index]) {
+                // For the last table, calculate position based on all previous content in the page
+                const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
+                oldToNewPosMap.set(oldPoses[index], basePos)
+              }
+            }
+          })
+        } else if (isPageFull) {
+            const pageNode = addPage(currentPageContent);
+            cumulativeNewDocPos += pageNode.nodeSize;
+            currentPageContent = [];
+            currentHeight = 0;
+            pageNum++;
+            if (isPageNumInRange(doc, pageNum)) {
+                ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
+            }
         }
-      } else {
-        const groupTables = contentNodes.filter(
-          (n) =>
-            n.node.type.name === 'table' &&
-            n.node.attrs.groupId === node.attrs.groupId,
-        )
-        const groupMeasurements = groupTables.map((t) =>
-          tableHandler.measureTable(t.node, t.pos, view),
-        )
-        groupTables.forEach((t, i) => {
-          // Store absolute position without adjustments
-          oldPoses.push(t.pos)
-        })
-        const { tables: optimisedTables, measurements: optimisedMeasurements } =
-          tableHandler.optimiseTables(
-            groupTables.map((t) => t.node),
-            groupMeasurements,
-            schema,
-            availableHeight,
-            pagePixelDimensions.pageContentHeight,
-          )
-        tables = optimisedTables.filter((table) =>
-          table && table.type && table.type.name === 'table' && table.content && table.content.content.length > 0
-        )
-        measurements = optimisedMeasurements.slice(0, tables.length)
-        i += groupTables.length
-      }
 
-      tables.forEach((table, index) => {
-        if (!table || !table.type || table.type.name !== 'table' || !table.content) {
-          console.warn('Invalid table encountered during pagination')
-          return
-        }
-        // insert current if the first entry exceeds height
-        if (index === 0 && measurements[index].totalHeight > availableHeight) {
-          if (oldPoses[index]) {
-            // Calculate position based on current page content plus the table's position within the page
-            const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
-            oldToNewPosMap.set(oldPoses[index], basePos)
-          }
-          const pageNode = addPage(currentPageContent)
-          cumulativeNewDocPos += pageNode.nodeSize
-          currentPageContent = []
-          currentHeight = 0
-          pageNum++
-          if (isPageNumInRange(doc, pageNum)) {
-            ;({ pageNodeAttributes, pagePixelDimensions } =
-              getCalculatedPageNodeAttributes(state, pageNum))
-          }
-        }
-        if (index < tables.length - 1) {
-          currentPageContent.push(table)
-          if (oldPoses[index]) {
-            // For tables at page boundaries, use cumulative position
-            const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
-            oldToNewPosMap.set(oldPoses[index], basePos)
-          }
-          const pageNode = addPage(currentPageContent)
-          cumulativeNewDocPos += pageNode.nodeSize
-          currentPageContent = []
-          currentHeight = 0
-          pageNum++
-          if (isPageNumInRange(doc, pageNum)) {
-            ;({ pageNodeAttributes, pagePixelDimensions } =
-              getCalculatedPageNodeAttributes(state, pageNum))
-          }
-        } else {
-          currentPageContent.push(table)
-          currentHeight += measurements[index].totalHeight
+        // Record the mapping from old position to new position
+        if (!isTable) {
+          const nodeStartPosInNewDoc = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0);
 
-          if (oldPoses[index]) {
-            // For the last table, calculate position based on all previous content in the page
-            const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
-            oldToNewPosMap.set(oldPoses[index], basePos)
-          }
+          oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc);
+
+          currentPageContent.push(node);
+          currentHeight += nodeHeight;
         }
-      })
-    } else if (isPageFull) {
-      const pageNode = addPage(currentPageContent)
-      cumulativeNewDocPos += pageNode.nodeSize
-      currentPageContent = []
-      currentHeight = 0
-      pageNum++
-      if (isPageNumInRange(doc, pageNum)) {
-        ;({ pageNodeAttributes, pagePixelDimensions } =
-          getCalculatedPageNodeAttributes(state, pageNum))
-      }
     }
-    // Record the mapping from old position to new position
-    if (!isTable) {
-      const nodeStartPosInNewDoc =
-        cumulativeNewDocPos +
-        currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
-      oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc)
-      currentPageContent.push(node)
-      currentHeight += nodeHeight
+
+    if (currentPageContent.length > 0) {
+        // Add final page (may not be full)
+        addPage(currentPageContent);
+    } else {
+        pageNum--;
     }
-  }
 
-  if (currentPageContent.length > 0) {
-    // Add final page (may not be full)
-    addPage(currentPageContent)
-  } else {
-    pageNum--
-  }
+    const newDoc = schema.topNodeType.create(null, pages);
+    const docSize = newDoc.content.size;
+    limitMappedCursorPositions(oldToNewPosMap, docSize);
 
-  const newDoc = schema.topNodeType.create(null, pages)
-  const docSize = newDoc.content.size
-  limitMappedCursorPositions(oldToNewPosMap, docSize)
-
-  return { newDoc, oldToNewPosMap }
-}
+    return { newDoc, oldToNewPosMap };
+};
 
 /***
  * Limit mapped cursor positions to document size to prevent out of bounds errors
@@ -956,16 +848,13 @@ export const buildNewDocument = (
  * @param docSize - The size of the new document.
  * @returns {void}
  */
-const limitMappedCursorPositions = (
-  oldToNewPosMap: CursorMap,
-  docSize: number,
-): void => {
-  oldToNewPosMap.forEach((newPos, oldPos) => {
-    if (newPos > docSize) {
-      oldToNewPosMap.set(oldPos, docSize)
-    }
-  })
-}
+const limitMappedCursorPositions = (oldToNewPosMap: CursorMap, docSize: number): void => {
+    oldToNewPosMap.forEach((newPos, oldPos) => {
+        if (newPos > docSize) {
+            oldToNewPosMap.set(oldPos, docSize);
+        }
+    });
+};
 
 /**
  * Map the cursor position from the old document to the new document.
@@ -976,35 +865,32 @@ const limitMappedCursorPositions = (
  * @returns {number} The new cursor position.
  */
 export const mapCursorPosition = (
-  contentNodes: NodePosArray,
-  oldCursorPos: number,
-  oldToNewPosMap: CursorMap,
-  newDocContentSize: number,
+    contentNodes: NodePosArray,
+    oldCursorPos: number,
+    oldToNewPosMap: CursorMap,
+    newDocContentSize: number
 ) => {
-  let newCursorPos: Nullable<number> = null
-  for (let i = 0; i < contentNodes.length; i++) {
-    const { node, pos: oldNodePos } = contentNodes[i]
-    const { nodeSize } = node
+    let newCursorPos: Nullable<number> = null;
+    for (let i = 0; i < contentNodes.length; i++) {
+        const { node, pos: oldNodePos } = contentNodes[i];
+        const nodeSize = node.nodeSize;
 
-    if (oldNodePos <= oldCursorPos && oldCursorPos <= oldNodePos + nodeSize) {
-      const offsetInNode = oldCursorPos - oldNodePos
-      const newNodePos = oldToNewPosMap.get(oldNodePos)
-      if (newNodePos === undefined) {
-        console.error('Unable to determine new node position from cursor map!')
-        newCursorPos = 0
-      } else {
-        newCursorPos = Math.min(
-          newNodePos + offsetInNode,
-          newDocContentSize - 1,
-        )
-      }
+        if (oldNodePos <= oldCursorPos && oldCursorPos <= oldNodePos + nodeSize) {
+            const offsetInNode = oldCursorPos - oldNodePos;
+            const newNodePos = oldToNewPosMap.get(oldNodePos);
+            if (newNodePos === undefined) {
+                console.error("Unable to determine new node position from cursor map!");
+                newCursorPos = 0;
+            } else {
+                newCursorPos = Math.min(newNodePos + offsetInNode, newDocContentSize - 1);
+            }
 
-      break
+            break;
+        }
     }
-  }
 
-  return newCursorPos
-}
+    return newCursorPos;
+};
 
 /**
  * Check if the given position is at the start of a text block.
@@ -1013,11 +899,8 @@ export const mapCursorPosition = (
  * @returns {boolean} True if the position is at the start of a text block, false otherwise.
  */
 const isNodeBeforeAvailable = ($pos: ResolvedPos): boolean => {
-  return (
-    !!$pos.nodeBefore &&
-    (isTextNode($pos.nodeBefore) || isParagraphNode($pos.nodeBefore))
-  )
-}
+    return !!$pos.nodeBefore && (isTextNode($pos.nodeBefore) || isParagraphNode($pos.nodeBefore));
+};
 
 /**
  * Check if the given position is at the end of a text block.
@@ -1026,42 +909,32 @@ const isNodeBeforeAvailable = ($pos: ResolvedPos): boolean => {
  * @returns {boolean} True if the position is at the end of a text block, false otherwise.
  */
 const isNodeAfterAvailable = ($pos: ResolvedPos): boolean => {
-  return (
-    !!$pos.nodeAfter &&
-    (isTextNode($pos.nodeAfter) || isParagraphNode($pos.nodeAfter))
-  )
-}
+    return !!$pos.nodeAfter && (isTextNode($pos.nodeAfter) || isParagraphNode($pos.nodeAfter));
+};
 
 /**
  * Sets the cursor selection after creating the new document.
  * @param tr - The current transaction.
  * @returns {void}
  */
-export const paginationUpdateCursorPosition = (
-  tr: Transaction,
-  newCursorPos: Nullable<number>,
-): void => {
-  if (newCursorPos !== null) {
-    const $pos = tr.doc.resolve(newCursorPos)
-    let selection
+export const paginationUpdateCursorPosition = (tr: Transaction, newCursorPos: Nullable<number>): void => {
+    if (newCursorPos !== null) {
+        const $pos = tr.doc.resolve(newCursorPos);
+        let selection;
 
-    if (
-      $pos.parent.isTextblock ||
-      isNodeBeforeAvailable($pos) ||
-      isNodeAfterAvailable($pos)
-    ) {
-      selection = moveToThisTextBlock(tr, $pos)
-    } else {
-      selection = moveToNearestValidCursorPosition($pos)
-    }
+        if ($pos.parent.isTextblock || isNodeBeforeAvailable($pos) || isNodeAfterAvailable($pos)) {
+            selection = moveToThisTextBlock(tr, $pos);
+        } else {
+            selection = moveToNearestValidCursorPosition($pos);
+        }
 
-    if (selection) {
-      setSelection(tr, selection)
+        if (selection) {
+            setSelection(tr, selection);
+        } else {
+            // Fallback to a safe selection at the end of the document
+            setSelectionAtEndOfDocument(tr);
+        }
     } else {
-      // Fallback to a safe selection at the end of the document
-      setSelectionAtEndOfDocument(tr)
+        setSelectionAtEndOfDocument(tr);
     }
-  } else {
-    setSelectionAtEndOfDocument(tr)
-  }
-}
+};

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -687,17 +687,20 @@ export const buildNewDocument = (
     const oldToNewPosMap: CursorMap = new Map<number, number>();
     let cumulativeNewDocPos = 1;
     const tableHandler = TableHandler.getInstance();
+    
     for (let i = 0; i < contentNodes.length; i++) {
         const { node, pos: oldPos } = contentNodes[i];
         const nodeHeight = nodeHeights[i];
 
         const isPageFull = currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight && currentPageContent.length > 0;
         const isTable = node.type.name === "table";
+
         if (isTable) {
             let tables: PMNode[] = [],
                 measurements: TableMeasurement[] = [];
             const availableHeight = pagePixelDimensions.pageContentHeight - currentHeight;
             const oldPoses: number[] = [];
+
             if (!node.attrs.groupId) {
                 const measurement = tableHandler.measureTable(node, oldPos, view);
                 const { tables: optimisedTables, measurements: optimisedMeasurements } = tableHandler.splitTableAtHeight(
@@ -739,6 +742,7 @@ export const buildNewDocument = (
                 }
                 // insert current if the first entry exceeds height
                 if (index === 0 && measurements[index].totalHeight > availableHeight) {
+
                     if (oldPoses[index]) {
                         // Calculate position based on current page content plus the table's position within the page
                         const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0);
@@ -749,12 +753,15 @@ export const buildNewDocument = (
                     currentPageContent = [];
                     currentHeight = 0;
                     pageNum++;
+
                     if (isPageNumInRange(doc, pageNum)) {
                         ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
                     }
                 }
+
                 if (index < tables.length - 1) {
                     currentPageContent.push(table);
+
                     if (oldPoses[index]) {
                         // For tables at page boundaries, use cumulative position
                         const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
@@ -765,6 +772,7 @@ export const buildNewDocument = (
                     currentPageContent = [];
                     currentHeight = 0;
                     pageNum++;
+
                     if (isPageNumInRange(doc, pageNum)) {
                         ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
                     }
@@ -793,9 +801,7 @@ export const buildNewDocument = (
         // Record the mapping from old position to new position
         if (!isTable) {
             const nodeStartPosInNewDoc = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0);
-
             oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc);
-
             currentPageContent.push(node);
             currentHeight += nodeHeight;
         }

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -761,7 +761,7 @@ export const buildNewDocument = (
 
                     if (oldPoses[index]) {
                         // For tables at page boundaries, use cumulative position
-                        const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
+                        const basePos = tableHandler.calculateNewBasePosition(cumulativeNewDocPos, currentPageContent);
                         oldToNewPosMap.set(oldPoses[index], basePos);
                     }
                     const pageNode = addPage(currentPageContent);
@@ -779,7 +779,7 @@ export const buildNewDocument = (
 
                     if (oldPoses[index]) {
                         // For the last table, calculate position based on all previous content in the page
-                        const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
+                        const basePos = tableHandler.calculateNewBasePosition(cumulativeNewDocPos, currentPageContent);
                         oldToNewPosMap.set(oldPoses[index], basePos);
                     }
                 }

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -753,7 +753,7 @@ export const buildNewDocument = (
               table?.type && table.type.name === 'table' && table.content && table.content.content.length > 0
             )
             measurements = optimisedMeasurements.slice(0, tables.length)
-            i += groupTables.length
+            i += groupTables.length - 1
           }
 
           tables.forEach((table, index) => {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -4,20 +4,31 @@
  * @description Utility functions for paginating the editor content.
  */
 
-import { Node as PMNode, ResolvedPos } from "@tiptap/pm/model";
-import { EditorState, Transaction } from "@tiptap/pm/state";
-import { EditorView } from "@tiptap/pm/view";
-import { MIN_PARAGRAPH_HEIGHT } from "../constants/tiptap";
-import { PAGE_NODE_NAME } from "../constants/page";
-import { NodePosArray } from "../types/node";
-import { CursorMap } from "../types/cursor";
-import { Nullable } from "../types/record";
-import { getParentNodePosOfType, getPositionNodeType, isNodeEmpty } from "./node";
-import { moveToNearestValidCursorPosition, moveToThisTextBlock, setSelection, setSelectionAtEndOfDocument } from "./selection";
-import { inRange } from "./math";
-import { collectPageNodes, isPageNode, isPageNumInRange } from "./page";
-import { getCalculatedPageNodeAttributes } from "./getPageAttributes";
-import { MarginConfig } from "../types/paper";
+import { Node as PMNode, ResolvedPos } from '@tiptap/pm/model'
+import { EditorState, Transaction } from '@tiptap/pm/state'
+import { EditorView } from '@tiptap/pm/view'
+
+import { PAGE_NODE_NAME } from '../constants/page'
+import { MIN_PARAGRAPH_HEIGHT } from '../constants/tiptap'
+import { CursorMap } from '../types/cursor'
+import { NodePosArray } from '../types/node'
+import { MarginConfig } from '../types/paper'
+import { Nullable } from '../types/record'
+import { getCalculatedPageNodeAttributes } from './getPageAttributes'
+import { inRange } from './math'
+import {
+  getParentNodePosOfType,
+  getPositionNodeType,
+  isNodeEmpty,
+} from './node'
+import { collectPageNodes, isPageNode, isPageNumInRange } from './page'
+import {
+  moveToNearestValidCursorPosition,
+  moveToThisTextBlock,
+  setSelection,
+  setSelectionAtEndOfDocument,
+} from './selection'
+import { TableHandler, TableMeasurement } from './table'
 
 /**
  * Check if the given node is a paragraph node.
@@ -25,13 +36,13 @@ import { MarginConfig } from "../types/paper";
  * @returns {boolean} True if the node is a paragraph node, false otherwise.
  */
 export const isParagraphNode = (node: Nullable<PMNode>): boolean => {
-    if (!node) {
-        console.warn("No node provided");
-        return false;
-    }
+  if (!node) {
+    console.warn('No node provided')
+    return false
+  }
 
-    return node.type.name === "paragraph";
-};
+  return node.type.name === 'paragraph'
+}
 
 /**
  * Check if the given node is a text node.
@@ -39,13 +50,13 @@ export const isParagraphNode = (node: Nullable<PMNode>): boolean => {
  * @returns {boolean} True if the node is a text node, false otherwise.
  */
 export const isTextNode = (node: Nullable<PMNode>): boolean => {
-    if (!node) {
-        console.warn("No node provided");
-        return false;
-    }
+  if (!node) {
+    console.warn('No node provided')
+    return false
+  }
 
-    return node.type.name === "text";
-};
+  return node.type.name === 'text'
+}
 
 /**
  * Get the type of the node at the specified position.
@@ -53,8 +64,8 @@ export const isTextNode = (node: Nullable<PMNode>): boolean => {
  * @returns The type of the node at the specified position.
  */
 export const isPositionWithinParagraph = ($pos: ResolvedPos): boolean => {
-    return getPositionNodeType($pos) === "paragraph";
-};
+  return getPositionNodeType($pos) === 'paragraph'
+}
 
 /**
  * Get the page node (parent of the current node) position.
@@ -62,9 +73,12 @@ export const isPositionWithinParagraph = ($pos: ResolvedPos): boolean => {
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The position of the page node.
  */
-export const getThisPageNodePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
-    return getParentNodePosOfType(doc, pos, PAGE_NODE_NAME).pos;
-};
+export const getThisPageNodePosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): number => {
+  return getParentNodePosOfType(doc, pos, PAGE_NODE_NAME).pos
+}
 
 /**
  * Get the paragraph node position.
@@ -72,9 +86,12 @@ export const getThisPageNodePosition = (doc: PMNode, pos: ResolvedPos | number):
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The position of the paragraph node.
  */
-export const getThisParagraphNodePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
-    return getParentNodePosOfType(doc, pos, "paragraph").pos;
-};
+export const getThisParagraphNodePosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): number => {
+  return getParentNodePosOfType(doc, pos, 'paragraph').pos
+}
 
 /**
  * Get the page node position and the page node itself.
@@ -82,20 +99,23 @@ export const getThisParagraphNodePosition = (doc: PMNode, pos: ResolvedPos | num
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {pagePos: number, pageNode: Node} The position and the node of the page.
  */
-export const getPageNodeAndPosition = (doc: PMNode, pos: ResolvedPos | number): { pagePos: number; pageNode: Nullable<PMNode> } => {
-    if (typeof pos === "number") {
-        return getPageNodeAndPosition(doc, doc.resolve(pos));
-    }
+export const getPageNodeAndPosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): { pagePos: number; pageNode: Nullable<PMNode> } => {
+  if (typeof pos === 'number') {
+    return getPageNodeAndPosition(doc, doc.resolve(pos))
+  }
 
-    const pagePos = getThisPageNodePosition(doc, pos);
-    const pageNode = doc.nodeAt(pagePos);
-    if (!isPageNode(pageNode)) {
-        console.warn("No page node found");
-        return { pagePos: -1, pageNode };
-    }
+  const pagePos = getThisPageNodePosition(doc, pos)
+  const pageNode = doc.nodeAt(pagePos)
+  if (!isPageNode(pageNode)) {
+    console.warn('No page node found')
+    return { pagePos: -1, pageNode }
+  }
 
-    return { pagePos, pageNode };
-};
+  return { pagePos, pageNode }
+}
 
 /**
  * Get the paragraph node position and the paragraph node itself.
@@ -104,32 +124,38 @@ export const getPageNodeAndPosition = (doc: PMNode, pos: ResolvedPos | number): 
  * @returns {paragraphPos: number, paragraphNode: Node} The position and the node of the paragraph.
  */
 export const getParagraphNodeAndPosition = (
-    doc: PMNode,
-    pos: ResolvedPos | number
+  doc: PMNode,
+  pos: ResolvedPos | number,
 ): { paragraphPos: number; paragraphNode: Nullable<PMNode> } => {
-    if (typeof pos === "number") {
-        return getParagraphNodeAndPosition(doc, doc.resolve(pos));
-    }
+  if (typeof pos === 'number') {
+    return getParagraphNodeAndPosition(doc, doc.resolve(pos))
+  }
 
-    if (isPosAtStartOfDocument(doc, pos, false)) {
-        // Find the next paragraph node
-        const { nextParagraphPos, nextParagraphNode } = getNextParagraph(doc, pos.pos);
-        return { paragraphPos: nextParagraphPos, paragraphNode: nextParagraphNode };
-    } else if (isPosAtEndOfDocument(doc, pos)) {
-        // Find the previous paragraph node
-        const { prevParagraphPos, prevParagraphNode } = getPreviousParagraph(doc, pos.pos);
-        return { paragraphPos: prevParagraphPos, paragraphNode: prevParagraphNode };
-    }
+  if (isPosAtStartOfDocument(doc, pos, false)) {
+    // Find the next paragraph node
+    const { nextParagraphPos, nextParagraphNode } = getNextParagraph(
+      doc,
+      pos.pos,
+    )
+    return { paragraphPos: nextParagraphPos, paragraphNode: nextParagraphNode }
+  } else if (isPosAtEndOfDocument(doc, pos)) {
+    // Find the previous paragraph node
+    const { prevParagraphPos, prevParagraphNode } = getPreviousParagraph(
+      doc,
+      pos.pos,
+    )
+    return { paragraphPos: prevParagraphPos, paragraphNode: prevParagraphNode }
+  }
 
-    const paragraphPos = getThisParagraphNodePosition(doc, pos);
-    const paragraphNode = doc.nodeAt(paragraphPos);
-    if (!isParagraphNode(paragraphNode)) {
-        console.warn("No paragraph node found");
-        return { paragraphPos: -1, paragraphNode };
-    }
+  const paragraphPos = getThisParagraphNodePosition(doc, pos)
+  const paragraphNode = doc.nodeAt(paragraphPos)
+  if (!isParagraphNode(paragraphNode)) {
+    console.warn('No paragraph node found')
+    return { paragraphPos: -1, paragraphNode }
+  }
 
-    return { paragraphPos, paragraphNode };
-};
+  return { paragraphPos, paragraphNode }
+}
 
 /**
  * Get the start of the page position.
@@ -137,15 +163,18 @@ export const getParagraphNodeAndPosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The start position of the page.
  */
-export const getStartOfPagePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
-    if (typeof pos === "number") {
-        return getStartOfPagePosition(doc, doc.resolve(pos));
-    }
+export const getStartOfPagePosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): number => {
+  if (typeof pos === 'number') {
+    return getStartOfPagePosition(doc, doc.resolve(pos))
+  }
 
-    const { pagePos } = getPageNodeAndPosition(doc, pos);
+  const { pagePos } = getPageNodeAndPosition(doc, pos)
 
-    return pagePos;
-};
+  return pagePos
+}
 
 /**
  * Get the start of the paragraph position.
@@ -153,14 +182,17 @@ export const getStartOfPagePosition = (doc: PMNode, pos: ResolvedPos | number): 
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The start position of the paragraph.
  */
-export const getStartOfParagraphPosition = (doc: PMNode, pos: ResolvedPos | number): number => {
-    if (typeof pos === "number") {
-        return getStartOfParagraphPosition(doc, doc.resolve(pos));
-    }
+export const getStartOfParagraphPosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): number => {
+  if (typeof pos === 'number') {
+    return getStartOfParagraphPosition(doc, doc.resolve(pos))
+  }
 
-    const { paragraphPos } = getParagraphNodeAndPosition(doc, pos);
-    return paragraphPos;
-};
+  const { paragraphPos } = getParagraphNodeAndPosition(doc, pos)
+  return paragraphPos
+}
 
 /**
  * Get the start of the page and paragraph positions.
@@ -169,14 +201,14 @@ export const getStartOfParagraphPosition = (doc: PMNode, pos: ResolvedPos | numb
  * @returns {startOfPagePos: number, startOfParagraphPos: number} The start positions of the page and paragraph.
  */
 export const getStartOfPageAndParagraphPosition = (
-    doc: PMNode,
-    pos: ResolvedPos | number
+  doc: PMNode,
+  pos: ResolvedPos | number,
 ): { startOfPagePos: number; startOfParagraphPos: number } => {
-    const startOfParagraphPos = getStartOfParagraphPosition(doc, pos);
-    const startOfPagePos = getStartOfPagePosition(doc, pos);
+  const startOfParagraphPos = getStartOfParagraphPosition(doc, pos)
+  const startOfPagePos = getStartOfPagePosition(doc, pos)
 
-    return { startOfPagePos, startOfParagraphPos };
-};
+  return { startOfPagePos, startOfParagraphPos }
+}
 
 /**
  * Get the end of the page position.
@@ -184,37 +216,43 @@ export const getStartOfPageAndParagraphPosition = (
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The end position of the page.
  */
-export const getEndOfPagePosition = (doc: PMNode, pos: ResolvedPos | number): number => {
-    if (typeof pos === "number") {
-        return getEndOfPagePosition(doc, doc.resolve(pos));
-    }
+export const getEndOfPagePosition = (
+  doc: PMNode,
+  pos: ResolvedPos | number,
+): number => {
+  if (typeof pos === 'number') {
+    return getEndOfPagePosition(doc, doc.resolve(pos))
+  }
 
-    const { pagePos, pageNode } = getPageNodeAndPosition(doc, pos);
-    if (!pageNode) {
-        return pagePos;
-    }
+  const { pagePos, pageNode } = getPageNodeAndPosition(doc, pos)
+  if (!pageNode) {
+    return pagePos
+  }
 
-    return pagePos + pageNode.content.size;
-};
+  return pagePos + pageNode.content.size
+}
 
 /**
  * Get the end of the paragraph position.
  * @param doc - The document node.
- * @param pos - The resolved position in the document or the absolute position of the node.
+ * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {number} The end position of the paragraph.
  */
-export const getEndOfParagraphPosition = (doc: PMNode, $pos: ResolvedPos | number): number => {
-    if (typeof $pos === "number") {
-        return getEndOfParagraphPosition(doc, doc.resolve($pos));
-    }
+export const getEndOfParagraphPosition = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): number => {
+  if (typeof $pos === 'number') {
+    return getEndOfParagraphPosition(doc, doc.resolve($pos))
+  }
 
-    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
-    if (!paragraphNode) {
-        return paragraphPos;
-    }
+  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
+  if (!paragraphNode) {
+    return paragraphPos
+  }
 
-    return paragraphPos + paragraphNode.content.size;
-};
+  return paragraphPos + paragraphNode.content.size
+}
 
 /**
  * Get the end of the page and paragraph positions.
@@ -223,70 +261,79 @@ export const getEndOfParagraphPosition = (doc: PMNode, $pos: ResolvedPos | numbe
  * @returns {endOfPagePos: number, endOfParagraphPos: number} The end positions of the page and paragraph.
  */
 export const getEndOfPageAndParagraphPosition = (
-    doc: PMNode,
-    $pos: ResolvedPos | number
+  doc: PMNode,
+  $pos: ResolvedPos | number,
 ): { endOfPagePos: number; endOfParagraphPos: number } => {
-    const endOfParagraphPos = getEndOfParagraphPosition(doc, $pos);
-    const endOfPagePos = getEndOfPagePosition(doc, $pos);
+  const endOfParagraphPos = getEndOfParagraphPosition(doc, $pos)
+  const endOfPagePos = getEndOfPagePosition(doc, $pos)
 
-    return { endOfPagePos, endOfParagraphPos };
-};
+  return { endOfPagePos, endOfParagraphPos }
+}
 
 /**
  * Check if the given position is at the start of the document.
  * @param state - The current editor state.
  * @returns True if text is currently highlighted, false otherwise.
  */
-const isPosMatchingStartOfPageCondition = (doc: PMNode, $pos: ResolvedPos | number, checkExactStart: boolean): boolean => {
-    // Resolve position if given as a number
-    if (typeof $pos === "number") {
-        return isPosMatchingStartOfPageCondition(doc, doc.resolve($pos), checkExactStart);
-    }
+const isPosMatchingStartOfPageCondition = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+  checkExactStart: boolean,
+): boolean => {
+  // Resolve position if given as a number
+  if (typeof $pos === 'number') {
+    return isPosMatchingStartOfPageCondition(
+      doc,
+      doc.resolve($pos),
+      checkExactStart,
+    )
+  }
 
-    // Check if we are at the start of the document
-    if (isPosAtStartOfDocument(doc, $pos, false)) {
-        return true;
-    }
+  // Check if we are at the start of the document
+  if (isPosAtStartOfDocument(doc, $pos, false)) {
+    return true
+  }
 
-    // Ensure that the position is within a valid block (paragraph)
-    if (!isPositionWithinParagraph($pos)) {
-        return false;
-    }
+  // Ensure that the position is within a valid block (paragraph)
+  if (!isPositionWithinParagraph($pos)) {
+    return false
+  }
 
-    // Get positions for paragraph and page
-    const { startOfPagePos, startOfParagraphPos } = getStartOfPageAndParagraphPosition(doc, $pos);
-    if (startOfPagePos < 0) {
-        console.warn("Invalid page position");
-        return false;
-    }
+  // Get positions for paragraph and page
+  const { startOfPagePos, startOfParagraphPos } =
+    getStartOfPageAndParagraphPosition(doc, $pos)
+  if (startOfPagePos < 0) {
+    console.warn('Invalid page position')
+    return false
+  }
 
-    if (startOfParagraphPos < 0) {
-        console.warn("Invalid paragraph position");
-        return false;
-    }
+  if (startOfParagraphPos < 0) {
+    console.warn('Invalid paragraph position')
+    return false
+  }
 
-    // Determine the condition to check
-    const isFirstParagraph = startOfPagePos + 1 === startOfParagraphPos;
-    if (checkExactStart) {
-        // Check if position is exactly at the start of the page
-        // First position of page will always be 1 more than the paragraph position
-        const isPosAtStartOfParagraph = $pos.pos - 1 === startOfParagraphPos;
-        if (isFirstParagraph && isPosAtStartOfParagraph) {
-            console.log("At the start of the page");
-            return true;
-        }
-        console.log("Not at the start of the page");
-        return false;
-    } else {
-        // Check if position is at the first child of the page
-        if (isFirstParagraph) {
-            console.log("In the first child of the page");
-            return true;
-        }
-        console.log("Not in the first child of the page");
-        return false;
+  // Determine the condition to check
+  const isFirstParagraph = startOfPagePos + 1 === startOfParagraphPos
+  if (checkExactStart) {
+    // Check if position is exactly at the start of the page
+    // First position of page will always be 1 more than the paragraph position
+    const isPosAtStartOfParagraph = $pos.pos - 1 === startOfParagraphPos
+    if (isFirstParagraph && isPosAtStartOfParagraph) {
+      console.log('At the start of the page')
+      return true
     }
-};
+    console.log('Not at the start of the page')
+    return false
+  } else {
+    // Check if position is at the first child of the page
+    if (isFirstParagraph) {
+      console.log('In the first child of the page')
+      return true
+    }
+    console.log('Not in the first child of the page')
+    return false
+  }
+}
 
 /**
  * Check if the given position is at the start of the page or the first child of the page.
@@ -294,9 +341,12 @@ const isPosMatchingStartOfPageCondition = (doc: PMNode, $pos: ResolvedPos | numb
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the condition is met, false otherwise.
  */
-export const isPosAtStartOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    return isPosMatchingStartOfPageCondition(doc, $pos, true);
-};
+export const isPosAtStartOfPage = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  return isPosMatchingStartOfPageCondition(doc, $pos, true)
+}
 
 /**
  * Check if the given position is at the first paragraph child of the page.
@@ -304,9 +354,12 @@ export const isPosAtStartOfPage = (doc: PMNode, $pos: ResolvedPos | number): boo
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the start of the page, false otherwise.
  */
-export const isPosAtFirstChildOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    return isPosMatchingStartOfPageCondition(doc, $pos, false);
-};
+export const isPosAtFirstChildOfPage = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  return isPosMatchingStartOfPageCondition(doc, $pos, false)
+}
 
 /**
  * Check if the given position is at the end of the page or the last child of the page.
@@ -315,53 +368,64 @@ export const isPosAtFirstChildOfPage = (doc: PMNode, $pos: ResolvedPos | number)
  * @param checkExactEnd - Whether to check for the exact end of the page (true) or the last child of the page (false).
  * @returns {boolean} True if the condition is met, false otherwise.
  */
-const isPosMatchingEndOfPageCondition = (doc: PMNode, $pos: ResolvedPos | number, checkExactEnd: boolean): boolean => {
-    // Resolve position if given as a number
-    if (typeof $pos === "number") {
-        return isPosMatchingEndOfPageCondition(doc, doc.resolve($pos), checkExactEnd);
-    }
+const isPosMatchingEndOfPageCondition = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+  checkExactEnd: boolean,
+): boolean => {
+  // Resolve position if given as a number
+  if (typeof $pos === 'number') {
+    return isPosMatchingEndOfPageCondition(
+      doc,
+      doc.resolve($pos),
+      checkExactEnd,
+    )
+  }
 
-    // Check if we are at the end of the document
-    if (isPosAtEndOfDocument(doc, $pos)) {
-        return true;
-    }
+  // Check if we are at the end of the document
+  if (isPosAtEndOfDocument(doc, $pos)) {
+    return true
+  }
 
-    // Ensure that the position is within a valid block (paragraph)
-    if (!isPositionWithinParagraph($pos)) {
-        return false;
-    }
+  // Ensure that the position is within a valid block (paragraph)
+  if (!isPositionWithinParagraph($pos)) {
+    return false
+  }
 
-    // Get positions for paragraph and page
-    const { endOfParagraphPos, endOfPagePos } = getEndOfPageAndParagraphPosition(doc, $pos);
-    if (endOfParagraphPos < 0) {
-        console.warn("Invalid end of paragraph position");
-        return false;
-    }
+  // Get positions for paragraph and page
+  const { endOfParagraphPos, endOfPagePos } = getEndOfPageAndParagraphPosition(
+    doc,
+    $pos,
+  )
+  if (endOfParagraphPos < 0) {
+    console.warn('Invalid end of paragraph position')
+    return false
+  }
 
-    if (endOfPagePos < 0) {
-        console.warn("Invalid end of page position");
-        return false;
-    }
+  if (endOfPagePos < 0) {
+    console.warn('Invalid end of page position')
+    return false
+  }
 
-    // Determine the condition to check
-    if (checkExactEnd) {
-        // Check if position is exactly at the end of the page
-        if ($pos.pos === endOfPagePos) {
-            console.log("At the end of the page");
-            return true;
-        }
-        console.log("Not at the end of the page");
-        return false;
-    } else {
-        // Check if position is at the last child of the page
-        if (endOfParagraphPos + 1 === endOfPagePos) {
-            console.log("In the last child of the page");
-            return true;
-        }
-        console.log("Not in the last child of the page");
-        return false;
+  // Determine the condition to check
+  if (checkExactEnd) {
+    // Check if position is exactly at the end of the page
+    if ($pos.pos === endOfPagePos) {
+      console.log('At the end of the page')
+      return true
     }
-};
+    console.log('Not at the end of the page')
+    return false
+  } else {
+    // Check if position is at the last child of the page
+    if (endOfParagraphPos + 1 === endOfPagePos) {
+      console.log('In the last child of the page')
+      return true
+    }
+    console.log('Not in the last child of the page')
+    return false
+  }
+}
 
 /**
  * Check if the given position is exactly at the end of the page.
@@ -369,9 +433,12 @@ const isPosMatchingEndOfPageCondition = (doc: PMNode, $pos: ResolvedPos | number
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the page, false otherwise.
  */
-export const isPosAtEndOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    return isPosMatchingEndOfPageCondition(doc, $pos, true);
-};
+export const isPosAtEndOfPage = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  return isPosMatchingEndOfPageCondition(doc, $pos, true)
+}
 
 /**
  * Check if the given position is at the last paragraph child of the page.
@@ -379,9 +446,12 @@ export const isPosAtEndOfPage = (doc: PMNode, $pos: ResolvedPos | number): boole
  * @param pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the page, false otherwise.
  */
-export const isPosAtLastChildOfPage = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    return isPosMatchingEndOfPageCondition(doc, $pos, false);
-};
+export const isPosAtLastChildOfPage = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  return isPosMatchingEndOfPageCondition(doc, $pos, false)
+}
 
 /**
  * Check if the given position is at the start of the document.
@@ -389,15 +459,19 @@ export const isPosAtLastChildOfPage = (doc: PMNode, $pos: ResolvedPos | number):
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the start of the document, false otherwise.
  */
-export const isPosAtStartOfDocument = (doc: PMNode, $pos: ResolvedPos | number, allowTextBlock: boolean): boolean => {
-    if (typeof $pos === "number") {
-        return isPosAtStartOfDocument(doc, doc.resolve($pos), allowTextBlock);
-    }
+export const isPosAtStartOfDocument = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+  allowTextBlock: boolean,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isPosAtStartOfDocument(doc, doc.resolve($pos), allowTextBlock)
+  }
 
-    const maxPos = allowTextBlock ? 2 : 1;
+  const maxPos = allowTextBlock ? 2 : 1
 
-    return $pos.pos <= maxPos;
-};
+  return $pos.pos <= maxPos
+}
 
 /**
  * Check if the given position is at the end of the document.
@@ -405,13 +479,16 @@ export const isPosAtStartOfDocument = (doc: PMNode, $pos: ResolvedPos | number, 
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the position is at the end of the document, false otherwise.
  */
-export const isPosAtEndOfDocument = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    if (typeof $pos === "number") {
-        return isPosAtEndOfDocument(doc, doc.resolve($pos));
-    }
+export const isPosAtEndOfDocument = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isPosAtEndOfDocument(doc, doc.resolve($pos))
+  }
 
-    return $pos.pos >= doc.nodeSize - 2;
-};
+  return $pos.pos >= doc.nodeSize - 2
+}
 
 /**
  * Get the previous paragraph node.
@@ -419,28 +496,31 @@ export const isPosAtEndOfDocument = (doc: PMNode, $pos: ResolvedPos | number): b
  * @param pos - The position in the document.
  * @returns {PMNode} The previous paragraph node.
  */
-export const getPreviousParagraph = (doc: PMNode, pos: number): { prevParagraphPos: number; prevParagraphNode: Nullable<PMNode> } => {
-    let prevParagraphPos = pos;
-    let prevParagraphNode = null;
-    while (prevParagraphNode === null && prevParagraphPos > 0) {
-        prevParagraphPos -= 1;
-        const node = doc.nodeAt(prevParagraphPos);
-        if (!node) {
-            continue;
-        }
-
-        if (isParagraphNode(node)) {
-            prevParagraphNode = node;
-            prevParagraphPos = prevParagraphPos;
-        }
+export const getPreviousParagraph = (
+  doc: PMNode,
+  pos: number,
+): { prevParagraphPos: number; prevParagraphNode: Nullable<PMNode> } => {
+  let prevParagraphPos = pos
+  let prevParagraphNode = null
+  while (prevParagraphNode === null && prevParagraphPos > 0) {
+    prevParagraphPos -= 1
+    const node = doc.nodeAt(prevParagraphPos)
+    if (!node) {
+      continue
     }
 
-    if (!prevParagraphNode) {
-        prevParagraphPos = -1;
+    if (isParagraphNode(node)) {
+      prevParagraphNode = node
+      prevParagraphPos = prevParagraphPos
     }
+  }
 
-    return { prevParagraphPos, prevParagraphNode };
-};
+  if (!prevParagraphNode) {
+    prevParagraphPos = -1
+  }
+
+  return { prevParagraphPos, prevParagraphNode }
+}
 
 /**
  * Get the next paragraph node.
@@ -448,29 +528,32 @@ export const getPreviousParagraph = (doc: PMNode, pos: number): { prevParagraphP
  * @param pos - The position in the document.
  * @returns {PMNode} The next paragraph node.
  */
-export const getNextParagraph = (doc: PMNode, pos: number): { nextParagraphPos: number; nextParagraphNode: Nullable<PMNode> } => {
-    const documentLength = doc.content.size;
-    let nextParagraphPos = pos;
-    let nextParagraphNode = null;
-    while (nextParagraphNode === null && nextParagraphPos < documentLength) {
-        nextParagraphPos += 1;
-        const node = doc.nodeAt(nextParagraphPos);
-        if (!node) {
-            continue;
-        }
-
-        if (isParagraphNode(node)) {
-            nextParagraphNode = node;
-            nextParagraphPos = nextParagraphPos;
-        }
+export const getNextParagraph = (
+  doc: PMNode,
+  pos: number,
+): { nextParagraphPos: number; nextParagraphNode: Nullable<PMNode> } => {
+  const documentLength = doc.content.size
+  let nextParagraphPos = pos
+  let nextParagraphNode = null
+  while (nextParagraphNode === null && nextParagraphPos < documentLength) {
+    nextParagraphPos += 1
+    const node = doc.nodeAt(nextParagraphPos)
+    if (!node) {
+      continue
     }
 
-    if (!nextParagraphNode) {
-        nextParagraphPos = -1;
+    if (isParagraphNode(node)) {
+      nextParagraphNode = node
+      nextParagraphPos = nextParagraphPos
     }
+  }
 
-    return { nextParagraphPos, nextParagraphNode };
-};
+  if (!nextParagraphNode) {
+    nextParagraphPos = -1
+  }
+
+  return { nextParagraphPos, nextParagraphNode }
+}
 
 /**
  * Determine if the resolved position is at the start of a paragraph node.
@@ -478,19 +561,22 @@ export const getNextParagraph = (doc: PMNode, pos: number): { nextParagraphPos: 
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the start of a paragraph node, false otherwise.
  */
-export const isAtStartOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    if (typeof $pos === "number") {
-        return isAtStartOfParagraph(doc, doc.resolve($pos));
-    }
+export const isAtStartOfParagraph = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isAtStartOfParagraph(doc, doc.resolve($pos))
+  }
 
-    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
-    if (!paragraphNode) {
-        return false;
-    }
+  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
+  if (!paragraphNode) {
+    return false
+  }
 
-    // We allow for the cursor to be at the start of the paragraph node or the start of the first text child node.
-    return inRange($pos.pos, paragraphPos, paragraphPos + 1);
-};
+  // We allow for the cursor to be at the start of the paragraph node or the start of the first text child node.
+  return inRange($pos.pos, paragraphPos, paragraphPos + 1)
+}
 
 /**
  * Determine if the resolved position is at the end of a paragraph node.
@@ -498,18 +584,21 @@ export const isAtStartOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): b
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the end of a paragraph node, false otherwise.
  */
-export const isAtEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    if (typeof $pos === "number") {
-        return isAtEndOfParagraph(doc, doc.resolve($pos));
-    }
+export const isAtEndOfParagraph = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isAtEndOfParagraph(doc, doc.resolve($pos))
+  }
 
-    const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos);
-    if (!paragraphNode) {
-        return false;
-    }
+  const { paragraphPos, paragraphNode } = getParagraphNodeAndPosition(doc, $pos)
+  if (!paragraphNode) {
+    return false
+  }
 
-    return $pos.pos + 1 === paragraphPos + paragraphNode.nodeSize;
-};
+  return $pos.pos + 1 === paragraphPos + paragraphNode.nodeSize
+}
 
 /**
  * Determine if the resolved position is at the start or end of a paragraph node.
@@ -517,9 +606,12 @@ export const isAtEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boo
  * @param $pos - The resolved position in the document.
  * @returns {boolean} True if the position is at the start or end of a paragraph node, false otherwise.
  */
-export const isAtStartOrEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    return isAtStartOfParagraph(doc, $pos) || isAtEndOfParagraph(doc, $pos);
-};
+export const isAtStartOrEndOfParagraph = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  return isAtStartOfParagraph(doc, $pos) || isAtEndOfParagraph(doc, $pos)
+}
 
 /**
  * Determine if the previous paragraph is empty.
@@ -527,18 +619,21 @@ export const isAtStartOrEndOfParagraph = (doc: PMNode, $pos: ResolvedPos | numbe
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the previous paragraph is empty or does not exist, false otherwise.
  */
-export const isPreviousParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    if (typeof $pos === "number") {
-        return isPreviousParagraphEmpty(doc, doc.resolve($pos));
-    }
+export const isPreviousParagraphEmpty = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isPreviousParagraphEmpty(doc, doc.resolve($pos))
+  }
 
-    const { prevParagraphNode } = getPreviousParagraph(doc, $pos.pos);
-    if (!prevParagraphNode) {
-        return false;
-    }
+  const { prevParagraphNode } = getPreviousParagraph(doc, $pos.pos)
+  if (!prevParagraphNode) {
+    return false
+  }
 
-    return isNodeEmpty(prevParagraphNode);
-};
+  return isNodeEmpty(prevParagraphNode)
+}
 
 /**
  * Determine if the next paragraph is empty.
@@ -546,18 +641,21 @@ export const isPreviousParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number
  * @param $pos - The resolved position in the document or the absolute position of the node.
  * @returns {boolean} True if the next paragraph is empty or does not exist, false otherwise.
  */
-export const isNextParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number): boolean => {
-    if (typeof $pos === "number") {
-        return isNextParagraphEmpty(doc, doc.resolve($pos));
-    }
+export const isNextParagraphEmpty = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+): boolean => {
+  if (typeof $pos === 'number') {
+    return isNextParagraphEmpty(doc, doc.resolve($pos))
+  }
 
-    const { nextParagraphNode } = getNextParagraph(doc, $pos.pos);
-    if (!nextParagraphNode) {
-        return false;
-    }
+  const { nextParagraphNode } = getNextParagraph(doc, $pos.pos)
+  if (!nextParagraphNode) {
+    return false
+  }
 
-    return isNodeEmpty(nextParagraphNode);
-};
+  return isNodeEmpty(nextParagraphNode)
+}
 
 /**
  * Get the page number of the resolved position.
@@ -566,21 +664,25 @@ export const isNextParagraphEmpty = (doc: PMNode, $pos: ResolvedPos | number): b
  * @param zeroIndexed - Whether to return the page number as zero-indexed. Default is true.
  * @returns {number} The page number of the resolved position.
  */
-export const getPageNumber = (doc: PMNode, $pos: ResolvedPos | number, zeroIndexed: boolean = true): number => {
-    if (typeof $pos === "number") {
-        return getPageNumber(doc, doc.resolve($pos));
-    }
+export const getPageNumber = (
+  doc: PMNode,
+  $pos: ResolvedPos | number,
+  zeroIndexed = true,
+): number => {
+  if (typeof $pos === 'number') {
+    return getPageNumber(doc, doc.resolve($pos))
+  }
 
-    const { pagePos } = getPageNodeAndPosition(doc, $pos);
-    if (pagePos < 0) {
-        console.log("Unable to find page node");
-        return -1;
-    }
+  const { pagePos } = getPageNodeAndPosition(doc, $pos)
+  if (pagePos < 0) {
+    console.log('Unable to find page node')
+    return -1
+  }
 
-    const pageNodes = collectPageNodes(doc);
-    const pageNode = pageNodes.findIndex((node) => node.pos === pagePos);
-    return pageNode + (zeroIndexed ? 0 : 1);
-};
+  const pageNodes = collectPageNodes(doc)
+  const pageNode = pageNodes.findIndex((node) => node.pos === pagePos)
+  return pageNode + (zeroIndexed ? 0 : 1)
+}
 
 /**
  * Collect content nodes and their old positions
@@ -588,22 +690,22 @@ export const getPageNumber = (doc: PMNode, $pos: ResolvedPos | number, zeroIndex
  * @returns {NodePosArray} The content nodes and their positions.
  */
 export const collectContentNodes = (state: EditorState): NodePosArray => {
-    const { schema } = state;
-    const pageType = schema.nodes.page;
+  const { schema } = state
+  const pageType = schema.nodes.page
 
-    const contentNodes: NodePosArray = [];
-    state.doc.forEach((node, offset) => {
-        if (node.type === pageType) {
-            node.forEach((child, childOffset) => {
-                contentNodes.push({ node: child, pos: offset + childOffset + 1 });
-            });
-        } else {
-            contentNodes.push({ node, pos: offset + 1 });
-        }
-    });
+  const contentNodes: NodePosArray = []
+  state.doc.forEach((node, offset) => {
+    if (node.type === pageType) {
+      node.forEach((child, childOffset) => {
+        contentNodes.push({ node: child, pos: offset + childOffset + 1 })
+      })
+    } else {
+      contentNodes.push({ node, pos: offset + 1 })
+    }
+  })
 
-    return contentNodes;
-};
+  return contentNodes
+}
 
 /**
  * Calculates the margins of the element.
@@ -611,14 +713,14 @@ export const collectContentNodes = (state: EditorState): NodePosArray => {
  * @returns {MarginConfig} The margins of the element.
  */
 const calculateElementMargins = (element: HTMLElement): MarginConfig => {
-    const style = window.getComputedStyle(element);
-    return {
-        top: parseFloat(style.marginTop),
-        right: parseFloat(style.marginRight),
-        bottom: parseFloat(style.marginBottom),
-        left: parseFloat(style.marginLeft),
-    };
-};
+  const style = window.getComputedStyle(element)
+  return {
+    top: parseFloat(style.marginTop),
+    right: parseFloat(style.marginRight),
+    bottom: parseFloat(style.marginBottom),
+    left: parseFloat(style.marginLeft),
+  }
+}
 
 /**
  * Measure the heights of the content nodes.
@@ -626,32 +728,35 @@ const calculateElementMargins = (element: HTMLElement): MarginConfig => {
  * @param contentNodes - The content nodes and their positions.
  * @returns {number[]} The heights of the content nodes.
  */
-export const measureNodeHeights = (view: EditorView, contentNodes: NodePosArray): number[] => {
-    const paragraphType = view.state.schema.nodes.paragraph;
+export const measureNodeHeights = (
+  view: EditorView,
+  contentNodes: NodePosArray,
+): number[] => {
+  const paragraphType = view.state.schema.nodes.paragraph
 
-    const nodeHeights = contentNodes.map(({ pos, node }) => {
-        const domNode = view.nodeDOM(pos);
-        if (domNode instanceof HTMLElement) {
-            let { height } = domNode.getBoundingClientRect();
+  const nodeHeights = contentNodes.map(({ pos, node }) => {
+    const domNode = view.nodeDOM(pos)
+    if (domNode instanceof HTMLElement) {
+      let { height } = domNode.getBoundingClientRect()
 
-            const { top: marginTop } = calculateElementMargins(domNode);
+      const { top: marginTop } = calculateElementMargins(domNode)
 
-            if (height === 0) {
-                if (node.type === paragraphType || node.isTextblock) {
-                    // Assign a minimum height to empty paragraphs or textblocks
-                    height = MIN_PARAGRAPH_HEIGHT;
-                }
-            }
-
-            // We use top margin only because there is overlap of margins between paragraphs
-            return height + marginTop;
+      if (height === 0) {
+        if (node.type === paragraphType || node.isTextblock) {
+          // Assign a minimum height to empty paragraphs or textblocks
+          height = MIN_PARAGRAPH_HEIGHT
         }
+      }
 
-        return MIN_PARAGRAPH_HEIGHT; // Default to minimum height if DOM element is not found
-    });
+      // We use top margin only because there is overlap of margins between paragraphs
+      return height + marginTop
+    }
 
-    return nodeHeights;
-};
+    return MIN_PARAGRAPH_HEIGHT // Default to minimum height if DOM element is not found
+  })
+
+  return nodeHeights
+}
 
 /**
  * Build the new document and keep track of new positions
@@ -661,67 +766,188 @@ export const measureNodeHeights = (view: EditorView, contentNodes: NodePosArray)
  * @returns {newDoc: PMNode, oldToNewPosMap: CursorMap} The new document and the mapping from old positions to new positions.
  */
 export const buildNewDocument = (
-    state: EditorState,
-    contentNodes: NodePosArray,
-    nodeHeights: number[]
+  state: EditorState,
+  contentNodes: NodePosArray,
+  nodeHeights: number[],
+  view: EditorView,
 ): { newDoc: PMNode; oldToNewPosMap: CursorMap } => {
-    const { schema, doc } = state;
-    let pageNum = 0;
+  const { schema, doc } = state
+  let pageNum = 0
 
-    const pageType = schema.nodes.page;
-    const pages: PMNode[] = [];
-    let { pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum);
+  const pageType = schema.nodes.page
+  const pages: PMNode[] = []
+  let { pageNodeAttributes, pagePixelDimensions } =
+    getCalculatedPageNodeAttributes(state, pageNum)
 
-    const addPage = (currentPageContent: PMNode[]): PMNode => {
-        const pageNode = pageType.create(pageNodeAttributes, currentPageContent);
-        pages.push(pageNode);
-        return pageNode;
-    };
+  const addPage = (currentPageContent: PMNode[]): PMNode => {
+    const pageNode = pageType.create(pageNodeAttributes, currentPageContent)
+    pages.push(pageNode)
+    return pageNode
+  }
 
-    let currentPageContent: PMNode[] = [];
-    let currentHeight = 0;
+  let currentPageContent: PMNode[] = []
+  let currentHeight = 0
 
-    const oldToNewPosMap: CursorMap = new Map<number, number>();
-    let cumulativeNewDocPos = 1;
+  const oldToNewPosMap: CursorMap = new Map<number, number>()
+  let cumulativeNewDocPos = 1
+  const tableHandler = TableHandler.getInstance()
+  for (let i = 0; i < contentNodes.length; i++) {
+    const { node, pos: oldPos } = contentNodes[i]
+    const nodeHeight = nodeHeights[i]
 
-    for (let i = 0; i < contentNodes.length; i++) {
-        const { node, pos: oldPos } = contentNodes[i];
-        const nodeHeight = nodeHeights[i];
+    const isPageFull =
+      currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight &&
+      currentPageContent.length > 0
 
-        const isPageFull = currentHeight + nodeHeight > pagePixelDimensions.pageContentHeight && currentPageContent.length > 0;
+    const isTable = node.type.name === 'table'
+    if (isTable) {
+      /**
+       * LOGIC
+       * if no groupId, measure the table and split based on either available height or pageContentHeight
+       * if already split
+       *  - gather tables
+       *  - for each table check against available height or max height
+       *  - if overflows, move rows to the next table (if not exist, create)
+       *  - if underflows, check if rows from next table can be moved to this table
+       *
+       */
+      let tables: PMNode[] = [],
+        measurements: TableMeasurement[] = []
+      const availableHeight =
+        pagePixelDimensions.pageContentHeight - currentHeight
+      const oldPoses: number[] = []
+      if (!node.attrs.groupId) {
+        const measurement = tableHandler.measureTable(node, oldPos, view)
+
         if (isPageFull) {
-            const pageNode = addPage(currentPageContent);
-            cumulativeNewDocPos += pageNode.nodeSize;
-            currentPageContent = [];
-            currentHeight = 0;
-            pageNum++;
-            if (isPageNumInRange(doc, pageNum)) {
-                ({ pageNodeAttributes, pagePixelDimensions } = getCalculatedPageNodeAttributes(state, pageNum));
-            }
+          // this has already checked whether the node fits
+          const {
+            tables: optimisedTables,
+            measurements: optimisedMeasurements,
+          } = tableHandler.splitTableAtHeight(
+            node,
+            availableHeight,
+            measurement,
+            schema,
+            pagePixelDimensions.pageContentHeight,
+          )
+          tables = optimisedTables.filter((table) =>
+            table && table.type && table.type.name === 'table' && table.content && table.content.content.length > 0
+          )
+          measurements = optimisedMeasurements.slice(0, tables.length)
         }
+      } else {
+        const groupTables = contentNodes.filter(
+          (n) =>
+            n.node.type.name === 'table' &&
+            n.node.attrs.groupId === node.attrs.groupId,
+        )
+        const groupMeasurements = groupTables.map((t) =>
+          tableHandler.measureTable(t.node, t.pos, view),
+        )
+        groupTables.forEach((t, i) => {
+          // Store absolute position without adjustments
+          oldPoses.push(t.pos)
+        })
+        const { tables: optimisedTables, measurements: optimisedMeasurements } =
+          tableHandler.optimiseTables(
+            groupTables.map((t) => t.node),
+            groupMeasurements,
+            schema,
+            availableHeight,
+            pagePixelDimensions.pageContentHeight,
+          )
+        tables = optimisedTables.filter((table) =>
+          table && table.type && table.type.name === 'table' && table.content && table.content.content.length > 0
+        )
+        measurements = optimisedMeasurements.slice(0, tables.length)
+        i += groupTables.length
+      }
 
-        // Record the mapping from old position to new position
-        const nodeStartPosInNewDoc = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0);
+      tables.forEach((table, index) => {
+        if (!table || !table.type || table.type.name !== 'table' || !table.content) {
+          console.warn('Invalid table encountered during pagination')
+          return
+        }
+        // insert current if the first entry exceeds height
+        if (index === 0 && measurements[index].totalHeight > availableHeight) {
+          if (oldPoses[index]) {
+            // Calculate position based on current page content plus the table's position within the page
+            const basePos = cumulativeNewDocPos + currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
+            oldToNewPosMap.set(oldPoses[index], basePos)
+          }
+          const pageNode = addPage(currentPageContent)
+          cumulativeNewDocPos += pageNode.nodeSize
+          currentPageContent = []
+          currentHeight = 0
+          pageNum++
+          if (isPageNumInRange(doc, pageNum)) {
+            ;({ pageNodeAttributes, pagePixelDimensions } =
+              getCalculatedPageNodeAttributes(state, pageNum))
+          }
+        }
+        if (index < tables.length - 1) {
+          currentPageContent.push(table)
+          if (oldPoses[index]) {
+            // For tables at page boundaries, use cumulative position
+            const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
+            oldToNewPosMap.set(oldPoses[index], basePos)
+          }
+          const pageNode = addPage(currentPageContent)
+          cumulativeNewDocPos += pageNode.nodeSize
+          currentPageContent = []
+          currentHeight = 0
+          pageNum++
+          if (isPageNumInRange(doc, pageNum)) {
+            ;({ pageNodeAttributes, pagePixelDimensions } =
+              getCalculatedPageNodeAttributes(state, pageNum))
+          }
+        } else {
+          currentPageContent.push(table)
+          currentHeight += measurements[index].totalHeight
 
-        oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc);
-
-        currentPageContent.push(node);
-        currentHeight += nodeHeight;
+          if (oldPoses[index]) {
+            // For the last table, calculate position based on all previous content in the page
+            const basePos = cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
+            oldToNewPosMap.set(oldPoses[index], basePos)
+          }
+        }
+      })
+    } else if (isPageFull) {
+      const pageNode = addPage(currentPageContent)
+      cumulativeNewDocPos += pageNode.nodeSize
+      currentPageContent = []
+      currentHeight = 0
+      pageNum++
+      if (isPageNumInRange(doc, pageNum)) {
+        ;({ pageNodeAttributes, pagePixelDimensions } =
+          getCalculatedPageNodeAttributes(state, pageNum))
+      }
     }
-
-    if (currentPageContent.length > 0) {
-        // Add final page (may not be full)
-        addPage(currentPageContent);
-    } else {
-        pageNum--;
+    // Record the mapping from old position to new position
+    if (!isTable) {
+      const nodeStartPosInNewDoc =
+        cumulativeNewDocPos +
+        currentPageContent.reduce((sum, n) => sum + n.nodeSize, 0)
+      oldToNewPosMap.set(oldPos, nodeStartPosInNewDoc)
+      currentPageContent.push(node)
+      currentHeight += nodeHeight
     }
+  }
 
-    const newDoc = schema.topNodeType.create(null, pages);
-    const docSize = newDoc.content.size;
-    limitMappedCursorPositions(oldToNewPosMap, docSize);
+  if (currentPageContent.length > 0) {
+    // Add final page (may not be full)
+    addPage(currentPageContent)
+  } else {
+    pageNum--
+  }
 
-    return { newDoc, oldToNewPosMap };
-};
+  const newDoc = schema.topNodeType.create(null, pages)
+  const docSize = newDoc.content.size
+  limitMappedCursorPositions(oldToNewPosMap, docSize)
+
+  return { newDoc, oldToNewPosMap }
+}
 
 /***
  * Limit mapped cursor positions to document size to prevent out of bounds errors
@@ -730,13 +956,16 @@ export const buildNewDocument = (
  * @param docSize - The size of the new document.
  * @returns {void}
  */
-const limitMappedCursorPositions = (oldToNewPosMap: CursorMap, docSize: number): void => {
-    oldToNewPosMap.forEach((newPos, oldPos) => {
-        if (newPos > docSize) {
-            oldToNewPosMap.set(oldPos, docSize);
-        }
-    });
-};
+const limitMappedCursorPositions = (
+  oldToNewPosMap: CursorMap,
+  docSize: number,
+): void => {
+  oldToNewPosMap.forEach((newPos, oldPos) => {
+    if (newPos > docSize) {
+      oldToNewPosMap.set(oldPos, docSize)
+    }
+  })
+}
 
 /**
  * Map the cursor position from the old document to the new document.
@@ -747,32 +976,35 @@ const limitMappedCursorPositions = (oldToNewPosMap: CursorMap, docSize: number):
  * @returns {number} The new cursor position.
  */
 export const mapCursorPosition = (
-    contentNodes: NodePosArray,
-    oldCursorPos: number,
-    oldToNewPosMap: CursorMap,
-    newDocContentSize: number
+  contentNodes: NodePosArray,
+  oldCursorPos: number,
+  oldToNewPosMap: CursorMap,
+  newDocContentSize: number,
 ) => {
-    let newCursorPos: Nullable<number> = null;
-    for (let i = 0; i < contentNodes.length; i++) {
-        const { node, pos: oldNodePos } = contentNodes[i];
-        const nodeSize = node.nodeSize;
+  let newCursorPos: Nullable<number> = null
+  for (let i = 0; i < contentNodes.length; i++) {
+    const { node, pos: oldNodePos } = contentNodes[i]
+    const { nodeSize } = node
 
-        if (oldNodePos <= oldCursorPos && oldCursorPos <= oldNodePos + nodeSize) {
-            const offsetInNode = oldCursorPos - oldNodePos;
-            const newNodePos = oldToNewPosMap.get(oldNodePos);
-            if (newNodePos === undefined) {
-                console.error("Unable to determine new node position from cursor map!");
-                newCursorPos = 0;
-            } else {
-                newCursorPos = Math.min(newNodePos + offsetInNode, newDocContentSize - 1);
-            }
+    if (oldNodePos <= oldCursorPos && oldCursorPos <= oldNodePos + nodeSize) {
+      const offsetInNode = oldCursorPos - oldNodePos
+      const newNodePos = oldToNewPosMap.get(oldNodePos)
+      if (newNodePos === undefined) {
+        console.error('Unable to determine new node position from cursor map!')
+        newCursorPos = 0
+      } else {
+        newCursorPos = Math.min(
+          newNodePos + offsetInNode,
+          newDocContentSize - 1,
+        )
+      }
 
-            break;
-        }
+      break
     }
+  }
 
-    return newCursorPos;
-};
+  return newCursorPos
+}
 
 /**
  * Check if the given position is at the start of a text block.
@@ -781,8 +1013,11 @@ export const mapCursorPosition = (
  * @returns {boolean} True if the position is at the start of a text block, false otherwise.
  */
 const isNodeBeforeAvailable = ($pos: ResolvedPos): boolean => {
-    return !!$pos.nodeBefore && (isTextNode($pos.nodeBefore) || isParagraphNode($pos.nodeBefore));
-};
+  return (
+    !!$pos.nodeBefore &&
+    (isTextNode($pos.nodeBefore) || isParagraphNode($pos.nodeBefore))
+  )
+}
 
 /**
  * Check if the given position is at the end of a text block.
@@ -791,32 +1026,42 @@ const isNodeBeforeAvailable = ($pos: ResolvedPos): boolean => {
  * @returns {boolean} True if the position is at the end of a text block, false otherwise.
  */
 const isNodeAfterAvailable = ($pos: ResolvedPos): boolean => {
-    return !!$pos.nodeAfter && (isTextNode($pos.nodeAfter) || isParagraphNode($pos.nodeAfter));
-};
+  return (
+    !!$pos.nodeAfter &&
+    (isTextNode($pos.nodeAfter) || isParagraphNode($pos.nodeAfter))
+  )
+}
 
 /**
  * Sets the cursor selection after creating the new document.
  * @param tr - The current transaction.
  * @returns {void}
  */
-export const paginationUpdateCursorPosition = (tr: Transaction, newCursorPos: Nullable<number>): void => {
-    if (newCursorPos !== null) {
-        const $pos = tr.doc.resolve(newCursorPos);
-        let selection;
+export const paginationUpdateCursorPosition = (
+  tr: Transaction,
+  newCursorPos: Nullable<number>,
+): void => {
+  if (newCursorPos !== null) {
+    const $pos = tr.doc.resolve(newCursorPos)
+    let selection
 
-        if ($pos.parent.isTextblock || isNodeBeforeAvailable($pos) || isNodeAfterAvailable($pos)) {
-            selection = moveToThisTextBlock(tr, $pos);
-        } else {
-            selection = moveToNearestValidCursorPosition($pos);
-        }
-
-        if (selection) {
-            setSelection(tr, selection);
-        } else {
-            // Fallback to a safe selection at the end of the document
-            setSelectionAtEndOfDocument(tr);
-        }
+    if (
+      $pos.parent.isTextblock ||
+      isNodeBeforeAvailable($pos) ||
+      isNodeAfterAvailable($pos)
+    ) {
+      selection = moveToThisTextBlock(tr, $pos)
     } else {
-        setSelectionAtEndOfDocument(tr);
+      selection = moveToNearestValidCursorPosition($pos)
     }
-};
+
+    if (selection) {
+      setSelection(tr, selection)
+    } else {
+      // Fallback to a safe selection at the end of the document
+      setSelectionAtEndOfDocument(tr)
+    }
+  } else {
+    setSelectionAtEndOfDocument(tr)
+  }
+}

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -99,6 +99,27 @@ export class TableHandler {
     }
 
     /**
+     * Determines the index at which to split a table based on available height.
+     * @param measurement The measurement details of the table.
+     * @param headerRowCount The number of header rows in the table.
+     * @param availableHeight The available height for the table on the current page.
+     * @returns The index at which to split the table.
+     */
+    private getSplitIndex(measurement: TableMeasurement, headerRowCount: number, availableHeight: number): [number, number] {
+        let splitIndex = headerRowCount;
+        let currentHeight = sumArray(measurement.rowHeights.slice(0, headerRowCount));
+
+        for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
+            if (currentHeight + measurement.rowHeights[i] > availableHeight) {
+                break;
+            }
+            currentHeight += measurement.rowHeights[i];
+            splitIndex = i + 1;
+        }
+        return [splitIndex, currentHeight];
+    }
+
+    /**
      * Split a table at a given height.
      * @param tableNode The table node to split.
      * @param availableHeight The available height for the table.
@@ -140,16 +161,7 @@ export class TableHandler {
         }
 
         // Find split point for current page
-        let splitIndex = headerRowCount;
-        let currentHeight = sumArray(measurement.rowHeights.slice(0, headerRowCount));
-
-        for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
-            if (currentHeight + measurement.rowHeights[i] > availableHeight) {
-                break;
-            }
-            currentHeight += measurement.rowHeights[i];
-            splitIndex = i + 1;
-        }
+        const [splitIndex, currentHeight] = this.getSplitIndex(measurement, headerRowCount, availableHeight);
 
         // Create first table with header rows
         const firstTableRows = rows.slice(0, splitIndex);
@@ -350,16 +362,18 @@ export class TableHandler {
      * @returns The filtered tables
      */
     filterTablesWithContent(tables: PMNode[]): PMNode[] {
-        return tables.filter(table => table?.type && table.type.name === TABLE_NODE_TYPE && table.content && table.content.content.length > 0);
+        return tables.filter(
+            (table) => table?.type && table.type.name === TABLE_NODE_TYPE && table.content && table.content.content.length > 0
+        );
     }
-    
+
     /**
      * Calculate new base position
      * @param cumulativeNewDocPos Current cumulutive position
      * @param currentPageContent Page content
-     * @returns 
+     * @returns
      */
     calculateNewBasePosition(cumulativeNewDocPos: number, currentPageContent: PMNode[]) {
-        return cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
+        return cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0);
     }
 }

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,0 +1,388 @@
+import { Node as PMNode } from '@tiptap/pm/model'
+import { EditorState } from '@tiptap/pm/state'
+import { EditorView } from '@tiptap/pm/view'
+
+export interface TableMeasurement {
+  rowHeights: number[]
+  headerRowCount: number
+  totalHeight: number
+  breakPoints: number[]
+  cumulativeHeights: number[]
+}
+
+interface TableSplitResult {
+  tables: PMNode[]
+  mapping: { from: number; to: number }[]
+  groupId: string
+  measurements: TableMeasurement[]
+}
+
+interface TableGroup {
+  tables: PMNode[]
+  originalTable: PMNode
+  positions: number[]
+}
+
+export class TableHandler {
+  private static instance: TableHandler
+  private measurementCache: Map<string, TableMeasurement> = new Map()
+  private tableGroups: Map<string, TableGroup> = new Map()
+  private originalTableMeasurements = new Map<string, number[]>()
+
+  static getInstance(): TableHandler {
+    if (!this.instance) {
+      this.instance = new TableHandler()
+    }
+    return this.instance
+  }
+
+  private getTableCacheKey(node: PMNode): string {
+    // Include content size and JSON to ensure cache invalidation on content changes
+    return `${node.type.name}-${node.content.size}-${JSON.stringify(node.toJSON())}`
+  }
+
+  measureTable(node: PMNode, pos: number, view: EditorView): TableMeasurement {
+    const cacheKey = this.getTableCacheKey(node)
+    const cached = this.measurementCache.get(cacheKey)
+    if (cached) return cached
+    const rows = node.content.content
+    const rowHeights = this.measureRowHeights(rows, pos, view)
+    const headerRowCount = this.getHeaderRowCount(node)
+
+    // Calculate cumulative heights
+    const cumulativeHeights = rowHeights.reduce((acc, height) => {
+      const prev = acc[acc.length - 1] || 0
+      acc.push(prev + height)
+      return acc
+    }, [] as number[])
+
+    const measurement = {
+      rowHeights,
+      headerRowCount,
+      totalHeight: cumulativeHeights[cumulativeHeights.length - 1] || 0,
+      breakPoints: [],
+      cumulativeHeights,
+    }
+
+    // Only cache if we have valid measurements
+    if (measurement.totalHeight > 0) {
+      this.measurementCache.set(cacheKey, measurement)
+    }
+
+    return measurement
+  }
+
+  private measureRowHeights(
+    rows: PMNode[],
+    pos: number,
+    view: EditorView,
+  ): number[] {
+    const dom = view.nodeDOM(pos) as HTMLElement
+    if (dom) {
+      const trs = dom.querySelectorAll('tr')
+      return rows.map((row, index) => {
+        const { height } = trs[index].getBoundingClientRect()
+        return height || row.nodeSize
+      })
+    }
+    // Get the group ID from the first row's parent table
+    const firstRow = rows[0]
+    const table = firstRow.type.name === 'table' ? firstRow : firstRow.parent
+    if (!table) {
+      return rows.map((row) => row.nodeSize)
+    }
+  }
+
+  private getHeaderRowCount(node: PMNode): number {
+    return node.attrs.headerRows || 1
+  }
+
+  splitTableAtHeight(
+    node: PMNode,
+    availableHeight: number,
+    measurement: TableMeasurement,
+    schema: EditorState['schema'],
+    pageHeight: number,
+  ): TableSplitResult {
+    const rows = node.content.content
+    const headerRowCount = this.getHeaderRowCount(node)
+    const tables: PMNode[] = []
+    const measurements: TableMeasurement[] = []
+    let mapping: { from: number; to: number }[] = []
+
+    // Check if table is already part of a group
+    const groupId = `table-group-${Date.now()}`
+
+    // If table fits in available height, return as is with groupId
+    if (measurement.totalHeight <= availableHeight) {
+      const table = schema.nodes.table.create(
+        {
+          ...node.attrs,
+          groupId,
+        },
+        node.content,
+      )
+      return {
+        tables: [table],
+        mapping: [],
+        groupId,
+        measurements: [measurement],
+      }
+    }
+
+    // Find split point for current page
+    let splitIndex = headerRowCount
+    let currentHeight = measurement.rowHeights
+      .slice(0, headerRowCount)
+      .reduce((a, b) => a + b, 0)
+
+    for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
+      if (currentHeight + measurement.rowHeights[i] > availableHeight) {
+        break
+      }
+      currentHeight += measurement.rowHeights[i]
+      splitIndex = i + 1
+    }
+
+    // Create first table with header rows
+    const firstTableRows = rows.slice(0, splitIndex)
+    const firstTable = schema.nodes.table.create(
+      {
+        ...node.attrs,
+        groupId,
+      },
+      firstTableRows,
+    )
+    tables.push(firstTable)
+    measurements.push({
+      headerRowCount: 0,
+      breakPoints: [],
+      rowHeights: measurement.rowHeights.slice(0, splitIndex),
+      cumulativeHeights: measurement.cumulativeHeights.slice(0, splitIndex),
+      totalHeight: measurement.rowHeights
+        .slice(0, splitIndex)
+        .reduce((a, b) => a + b, 0),
+    })
+
+    // Handle remaining rows
+    if (splitIndex < rows.length) {
+      const remainingRows = rows.slice(splitIndex)
+      const remainingTable = schema.nodes.table.create(
+        {
+          ...node.attrs,
+          groupId,
+        },
+        remainingRows,
+      )
+
+      // Calculate remaining table measurement
+      const remainingMeasurement = {
+        ...measurement,
+        rowHeights: measurement.rowHeights.slice(splitIndex),
+        cumulativeHeights: measurement.cumulativeHeights
+          .slice(splitIndex)
+          .map((h) => h - currentHeight),
+        totalHeight: measurement.rowHeights
+          .slice(splitIndex)
+          .reduce((a, b) => a + b, 0),
+      }
+
+      // Recursively split remaining table if needed
+      if (remainingMeasurement.totalHeight > pageHeight) {
+        const result = this.splitTableAtHeight(
+          remainingTable,
+          pageHeight,
+          remainingMeasurement,
+          schema,
+          pageHeight,
+        )
+
+        // Adjust mapping for the offset caused by the first table
+        const firstTableSize = firstTable.nodeSize
+        const adjustedMapping = result.mapping.map(({ from, to }) => ({
+          from: from + splitIndex,
+          to: to + firstTableSize,
+        }))
+
+        tables.push(...result.tables)
+        measurements.push(...result.measurements)
+        mapping = [...mapping, ...adjustedMapping]
+      } else {
+        measurements.push(remainingMeasurement)
+        tables.push(remainingTable)
+      }
+    }
+
+    // Store or update table group
+    const originalTable = node.attrs.groupId
+      ? this.tableGroups.get(node.attrs.groupId)?.originalTable || node
+      : node
+
+    this.tableGroups.set(groupId, {
+      tables,
+      originalTable,
+      positions: [], // Positions will be updated in buildNewDocument
+    })
+
+    return { tables, mapping, groupId, measurements }
+  }
+
+  /**
+   * For each table in a group
+   * - compare against maxHeight (table 0 against available height, the rest aginast page heigt)
+   * - if the table overflows.
+   * -- then
+   * -- calculate overflow rows
+   * --- if next table exists
+   * ---- then move to next table
+   * --- else
+   * ---- create new table
+   * -- else if table underflows and next table
+   * --- get max fit rows in underflow from next table
+   * --- add to current table
+   * @param tables
+   * @param measurements
+   * @param schema
+   * @param availableHeight
+   * @param pageHeight
+   * @returns
+   */
+  optimiseTables(
+    tables: PMNode[],
+    measurements: TableMeasurement[],
+    schema: EditorState['schema'],
+    availableHeight: number,
+    pageHeight: number,
+  ) {
+    const optimisedTables: PMNode[] = []
+    const optimisedMeasurements: TableMeasurement[] = []
+
+    tables.forEach((table, index) => {
+      let optimised = false
+      const rows = table.content.content
+      const measurement = measurements[index]
+      const tableHeight = measurement.totalHeight
+      const availableSpace = index === 0 ? availableHeight : pageHeight
+
+      // handle overflows
+      if (measurement.totalHeight > availableSpace) {
+        const maxFitSpace = availableSpace - tableHeight
+        const rows = table.content.content
+        const rowsToMove: PMNode[] = []
+        const movedRowMeasurements: number[] = []
+        let totalSpaceTaken = 0
+        let rowsToRemove = 0
+        for (let i = rows.length - 1; i >= 0; i--) {
+          const rowHeight = measurement.rowHeights[i]
+          if (tableHeight - totalSpaceTaken <= availableSpace) break
+
+          rowsToMove.unshift(rows[i])
+          movedRowMeasurements.unshift(rowHeight)
+          totalSpaceTaken += rowHeight
+          rowsToRemove++
+        }
+        if (rowsToMove.length) {
+          optimised = true
+          // Create new content for the current table
+          optimisedTables.push(
+            schema.nodes.table.create(
+              { ...table.attrs },
+              rows.slice(0, -rowsToMove.length),
+            ),
+          )
+          // add a new measurement for the adjusted table
+          optimisedMeasurements.push({
+            rowHeights: measurement.rowHeights.slice(0, -rowsToMove.length),
+            headerRowCount: 0,
+            totalHeight: measurement.totalHeight - totalSpaceTaken,
+            breakPoints: measurement.breakPoints,
+            cumulativeHeights: measurement.cumulativeHeights.slice(
+              0,
+              -rowsToMove.length,
+            ),
+          })
+
+          if (tables[index + 1]) {
+            const nextTable = tables[index + 1]
+            const rows = [...rowsToMove, ...nextTable.content.content]
+            // replaces next child so this is repeated
+            tables[index + 1] = schema.nodes.table.create(
+              { ...nextTable.attrs },
+              rows,
+            )
+            measurements[index + 1].rowHeights.unshift(...movedRowMeasurements)
+            measurements[index + 1].totalHeight += totalSpaceTaken
+          } else {
+            const newTable = schema.nodes.table.create(
+              { ...table.attrs },
+              rowsToMove,
+            )
+            optimisedTables.push(newTable)
+            optimisedMeasurements.push({
+              ...measurement,
+              rowHeights: movedRowMeasurements,
+              totalHeight: movedRowMeasurements.reduce(
+                (sum, height) => sum + height,
+                0,
+              ),
+            })
+          }
+        }
+      }
+      if (measurement.totalHeight < availableSpace && tables[index + 1]) {
+        const availableHeight = availableSpace - measurement.totalHeight
+        const nextTable = tables[index + 1]
+        const nextTableMeasurements = measurements[index + 1]
+        const nextTableRows = nextTable.content.content
+        const rowsToMove: PMNode[] = []
+        const movedRowMeasurements: number[] = []
+        let totalSpaceTaken = 0
+        let rowsToAdd = 0
+        for (let i = 0; i < nextTableRows.length; i++) {
+          const rowHeight = nextTableMeasurements.rowHeights[i]
+          if (availableHeight - totalSpaceTaken <= rowHeight) break
+
+          rowsToMove.push(nextTableRows[i])
+          movedRowMeasurements.push(rowHeight)
+          totalSpaceTaken += rowHeight
+          rowsToAdd++
+        }
+        if (rowsToAdd) {
+          optimised = true
+          // push current table optimised
+          const rows = [...table.content.content, ...rowsToMove]
+          optimisedTables.push(
+            schema.nodes.table.create({ ...table.attrs }, rows),
+          )
+          optimisedMeasurements.push({
+            ...nextTableMeasurements,
+            totalHeight: measurement.totalHeight + totalSpaceTaken,
+            rowHeights: measurement.rowHeights.slice(0, rowsToAdd),
+            cumulativeHeights: [
+              ...measurement.cumulativeHeights,
+              ...nextTableMeasurements.cumulativeHeights.slice(0, rowsToAdd),
+            ],
+          })
+
+          // remove rows from next table
+          tables[index + 1] = schema.nodes.table.create(
+            { ...nextTable.attrs },
+            nextTableRows.slice(rowsToAdd),
+          )
+          measurements[index + 1].rowHeights =
+            measurements[index + 1].rowHeights.slice(rowsToAdd)
+          measurements[index + 1].cumulativeHeights =
+            measurements[index + 1].cumulativeHeights.slice(rowsToAdd)
+          measurements[index + 1].totalHeight -= totalSpaceTaken
+        }
+      }
+
+      if (!optimised) {
+        optimisedTables.push(table)
+        optimisedMeasurements.push(measurement)
+      }
+    })
+
+    return { tables: optimisedTables, measurements: optimisedMeasurements }
+  }
+}

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,6 +1,7 @@
 import { Node as PMNode, Schema } from "@tiptap/pm/model";
 import { EditorView } from "@tiptap/pm/view";
 import { TableGroup, TableMeasurement, TableSplitResult } from "../types/table";
+import { TABLE_NODE_TYPE } from "../constants/table";
 
 export class TableHandler {
     private static instance: TableHandler;
@@ -83,7 +84,7 @@ export class TableHandler {
         }
         // Fallback to using nodeSize if DOM is not available
         const firstRow = rows[0];
-        const table = firstRow.type.name === "table" ? firstRow : firstRow.parent;
+        const table = firstRow.type.name === TABLE_NODE_TYPE ? firstRow : firstRow.parent;
         if (!table) {
             return rows.map((row) => row.nodeSize);
         }
@@ -117,7 +118,6 @@ export class TableHandler {
         const measurements: TableMeasurement[] = [];
         let mapping: { from: number; to: number }[] = [];
 
-        // Check if table is already part of a group
         const groupId = `table-group-${Date.now()}`;
 
         // If table fits in available height, return as is with groupId
@@ -341,5 +341,13 @@ export class TableHandler {
         });
 
         return { tables: optimisedTables, measurements: optimisedMeasurements };
+    }
+    /**
+     * Filter tables with content
+     * @param tables The tables to filter
+     * @returns The filtered tables
+     */
+    filterTablesWithContent(tables: PMNode[]): PMNode[] {
+        return tables.filter(table => table?.type && table.type.name === TABLE_NODE_TYPE && table.content && table.content.content.length > 0);
     }
 }

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -3,395 +3,343 @@ import { EditorView } from "@tiptap/pm/view";
 import { TableGroup, TableMeasurement, TableSplitResult } from "../types/table";
 
 export class TableHandler {
-  private static instance: TableHandler;
-  private measurementCache: Map<string, TableMeasurement> = new Map();
-  private tableGroups: Map<string, TableGroup> = new Map();
+    private static instance: TableHandler;
+    private measurementCache: Map<string, TableMeasurement> = new Map();
+    private tableGroups: Map<string, TableGroup> = new Map();
 
-  /**
-   * Get the singleton instance of the TableHandler.
-   * @returns The singleton instance of the TableHandler.
-   */
-  static getInstance(): TableHandler {
-    if (!this.instance) {
-      this.instance = new TableHandler();
-    }
-    return this.instance;
-  }
-
-  /**
-   * Get a cache key for a table node.
-   * @param node The table node.
-   * @returns The cache key as a string.
-   */
-  private getTableCacheKey(node: PMNode): string {
-    return `${node.type.name}-${node.content.size}-${JSON.stringify(
-      node.toJSON()
-    )}`;
-  }
-
-  /**
-   * Measure the height of a table.
-   * @param node The table node.
-   * @param pos The position of the table in the document.
-   * @param view The editor view.
-   * @returns The measurement of the table.
-   */
-  measureTable(node: PMNode, pos: number, view: EditorView): TableMeasurement {
-    const cacheKey = this.getTableCacheKey(node);
-    const cached = this.measurementCache.get(cacheKey);
-    if (cached) return cached;
-    const rows = node.content.content;
-    const rowHeights = this.measureRowHeights(rows, pos, view);
-    const headerRowCount = this.getHeaderRowCount(node);
-
-    // Calculate cumulative heights
-    const cumulativeHeights = rowHeights.reduce((acc, height) => {
-      const prev = acc[acc.length - 1] ?? 0;
-      acc.push(prev + height);
-      return acc;
-    }, [] as number[]);
-
-    const measurement = {
-      rowHeights,
-      headerRowCount,
-      totalHeight: cumulativeHeights[cumulativeHeights.length - 1] ?? 0,
-      breakPoints: [],
-      cumulativeHeights,
-    };
-
-    // Only cache if we have valid measurements
-    if (measurement.totalHeight > 0) {
-      this.measurementCache.set(cacheKey, measurement);
+    /**
+     * Get the singleton instance of the TableHandler.
+     * @returns The singleton instance of the TableHandler.
+     */
+    static getInstance(): TableHandler {
+        if (!this.instance) {
+            this.instance = new TableHandler();
+        }
+        return this.instance;
     }
 
-    return measurement;
-  }
-
-  /**
-   * Measures the heights of rows in a table.
-   * @param rows The rows to measure.
-   * @param pos The position of the table in the document.
-   * @param view The editor view.
-   * @returns An array of row heights.
-   */
-  private measureRowHeights(
-    rows: PMNode[],
-    pos: number,
-    view: EditorView
-  ): number[] {
-    const dom = view.nodeDOM(pos) as HTMLElement;
-    if (dom) {
-      const trs = dom.querySelectorAll("tr");
-      return rows.map((row, index) => {
-        const { height } = trs[index].getBoundingClientRect();
-        return height || row.nodeSize;
-      });
-    }
-    // Fallback to using nodeSize if DOM is not available
-    const firstRow = rows[0];
-    const table = firstRow.type.name === "table" ? firstRow : firstRow.parent;
-    if (!table) {
-      return rows.map((row) => row.nodeSize);
-    }
-    // If table exists but DOM is not available, use nodeSize
-    return rows.map((row) => row.nodeSize);
-  }
-
-  private getHeaderRowCount(node: PMNode): number {
-    return node.attrs.headerRows || 0;
-  }
-
-  /**
-   * Split a table at a given height.
-   * @param tableNode The table node to split.
-   * @param availableHeight The available height for the table.
-   * @param measurement The measurement of the table.
-   * @param schema The schema of the document.
-   * @param pageHeight The height of the page.
-   * @returns The split result containing the tables, measurements, and mapping.
-   */
-  splitTableAtHeight(
-    tableNode: PMNode,
-    availableHeight: number,
-    measurement: TableMeasurement,
-    schema: Schema,
-    pageHeight: number
-  ): TableSplitResult {
-    const rows = tableNode.content.content;
-    const headerRowCount = this.getHeaderRowCount(tableNode);
-    const tables: PMNode[] = [];
-    const measurements: TableMeasurement[] = [];
-    let mapping: { from: number; to: number }[] = [];
-
-    // Check if table is already part of a group
-    const groupId = `table-group-${Date.now()}`;
-
-    // If table fits in available height, return as is with groupId
-    if (measurement.totalHeight <= availableHeight) {
-      const table = schema.nodes.table.create(
-        {
-          ...tableNode.attrs,
-          groupId,
-        },
-        tableNode.content
-      );
-      return {
-        tables: [table],
-        mapping: [],
-        groupId,
-        measurements: [measurement],
-      };
+    /**
+     * Get a cache key for a table node.
+     * @param node The table node.
+     * @returns The cache key as a string.
+     */
+    private getTableCacheKey(node: PMNode): string {
+        return `${node.type.name}-${node.content.size}-${JSON.stringify(node.toJSON())}`;
     }
 
-    // Find split point for current page
-    let splitIndex = headerRowCount;
-    let currentHeight = measurement.rowHeights
-      .slice(0, headerRowCount)
-      .reduce((a, b) => a + b, 0);
+    /**
+     * Measure the height of a table.
+     * @param node The table node.
+     * @param pos The position of the table in the document.
+     * @param view The editor view.
+     * @returns The measurement of the table.
+     */
+    measureTable(node: PMNode, pos: number, view: EditorView): TableMeasurement {
+        const cacheKey = this.getTableCacheKey(node);
+        const cached = this.measurementCache.get(cacheKey);
+        if (cached) return cached;
+        const rows = node.content.content;
+        const rowHeights = this.measureRowHeights(rows, pos, view);
+        const headerRowCount = this.getHeaderRowCount(node);
 
-    for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
-      if (currentHeight + measurement.rowHeights[i] > availableHeight) {
-        break;
-      }
-      currentHeight += measurement.rowHeights[i];
-      splitIndex = i + 1;
-    }
+        // Calculate cumulative heights
+        const cumulativeHeights = rowHeights.reduce((acc, height) => {
+            const prev = acc[acc.length - 1] ?? 0;
+            acc.push(prev + height);
+            return acc;
+        }, [] as number[]);
 
-    // Create first table with header rows
-    const firstTableRows = rows.slice(0, splitIndex);
-    const firstTable = schema.nodes.table.create(
-      {
-        ...tableNode.attrs,
-        groupId,
-      },
-      firstTableRows
-    );
-    tables.push(firstTable);
-    measurements.push({
-      headerRowCount: 0,
-      breakPoints: [],
-      rowHeights: measurement.rowHeights.slice(0, splitIndex),
-      cumulativeHeights: measurement.cumulativeHeights.slice(0, splitIndex),
-      totalHeight: measurement.rowHeights
-        .slice(0, splitIndex)
-        .reduce((a, b) => a + b, 0),
-    });
+        const measurement = {
+            rowHeights,
+            headerRowCount,
+            totalHeight: cumulativeHeights[cumulativeHeights.length - 1] ?? 0,
+            breakPoints: [],
+            cumulativeHeights,
+        };
 
-    // Handle remaining rows
-    if (splitIndex < rows.length) {
-      const remainingRows = rows.slice(splitIndex);
-      const remainingTable = schema.nodes.table.create(
-        {
-          ...tableNode.attrs,
-          groupId,
-        },
-        remainingRows
-      );
-
-      // Calculate remaining table measurement
-      const remainingMeasurement = {
-        ...measurement,
-        rowHeights: measurement.rowHeights.slice(splitIndex),
-        cumulativeHeights: measurement.cumulativeHeights
-          .slice(splitIndex)
-          .map((h) => h - currentHeight),
-        totalHeight: measurement.rowHeights
-          .slice(splitIndex)
-          .reduce((a, b) => a + b, 0),
-      };
-
-      // Recursively split remaining table if needed
-      if (remainingMeasurement.totalHeight > pageHeight) {
-        const result = this.splitTableAtHeight(
-          remainingTable,
-          pageHeight,
-          remainingMeasurement,
-          schema,
-          pageHeight
-        );
-
-        // Adjust mapping for the offset caused by the first table
-        const firstTableSize = firstTable.nodeSize;
-        const adjustedMapping = result.mapping.map(({ from, to }) => ({
-          from: from + splitIndex,
-          to: to + firstTableSize,
-        }));
-
-        tables.push(...result.tables);
-        measurements.push(...result.measurements);
-        mapping = [...mapping, ...adjustedMapping];
-      } else {
-        measurements.push(remainingMeasurement);
-        tables.push(remainingTable);
-      }
-    }
-
-    // Store or update table group
-    const originalTable = tableNode.attrs.groupId
-      ? this.tableGroups.get(tableNode.attrs.groupId)?.originalTable || tableNode
-      : tableNode;
-
-    this.tableGroups.set(groupId, {
-      tables,
-      originalTable,
-      positions: [], // Positions will be updated in buildNewDocument
-    });
-
-    return { tables, mapping, groupId, measurements };
-  }
-
-  /**
-   * Function to optimise a group of split tables by checking the length of the table and moving the rows between tables.
-   * @param tables The table(s) in a group which need to be checked.
-   * @param measurements The measurements of each table
-   * @param schema The schema of the document.
-   * @param availableHeight The available height in the current page
-   * @param pageHeight The height of a page.
-   * @returns The optimised tables, measurements, and updated mapping.
-   */
-  optimiseTables(
-    tables: PMNode[],
-    measurements: TableMeasurement[],
-    schema: Schema,
-    availableHeight: number,
-    pageHeight: number
-  ) {
-    const optimisedTables: PMNode[] = [];
-    const optimisedMeasurements: TableMeasurement[] = [];
-
-    tables.forEach((table, index) => {
-      let isOptimised: boolean = false;
-      const nextRowIndex = index + 1;
-      const measurement = measurements[index];
-      const tableHeight = measurement.totalHeight;
-      const availableSpace = index === 0 ? availableHeight : pageHeight;
-
-      // handle overflows
-      if (measurement.totalHeight > availableSpace) {
-        const rows = table.content.content;
-        const rowsToMove: PMNode[] = [];
-        const movedRowMeasurements: number[] = [];
-        let totalSpaceTaken = 0;
-        let rowsToRemove = 0;
-
-        for (let i = rows.length - 1; i >= 0; i--) {
-          const rowHeight = measurement.rowHeights[i];
-
-          if (tableHeight - totalSpaceTaken <= availableSpace) break;
-
-          rowsToMove.unshift(rows[i]);
-          movedRowMeasurements.unshift(rowHeight);
-          totalSpaceTaken += rowHeight;
-          rowsToRemove++;
+        // Only cache if we have valid measurements
+        if (measurement.totalHeight > 0) {
+            this.measurementCache.set(cacheKey, measurement);
         }
 
-        if (rowsToMove.length) {
-          isOptimised = true;
-          // Create new content for the current table
-          optimisedTables.push(
-            schema.nodes.table.create(
-              { ...table.attrs },
-              rows.slice(0, -rowsToMove.length)
-            )
-          );
-          // add a new measurement for the adjusted table
-          optimisedMeasurements.push({
-            rowHeights: measurement.rowHeights.slice(0, -rowsToMove.length),
-            headerRowCount: 0,
-            totalHeight: measurement.totalHeight - totalSpaceTaken,
-            breakPoints: measurement.breakPoints,
-            cumulativeHeights: measurement.cumulativeHeights.slice(
-              0,
-              -rowsToMove.length
-            ),
-          });
+        return measurement;
+    }
 
-          if (tables[nextRowIndex]) {
-            const nextTable = tables[nextRowIndex];
-            const rows = [...rowsToMove, ...nextTable.content.content];
-            // replaces next child so this is repeated
-            tables[nextRowIndex] = schema.nodes.table.create(
-              { ...nextTable.attrs },
-              rows
-            );
-            measurements[nextRowIndex].rowHeights.unshift(
-              ...movedRowMeasurements
-            );
-            measurements[nextRowIndex].totalHeight += totalSpaceTaken;
-          } else {
-            const newTable = schema.nodes.table.create(
-              { ...table.attrs },
-              rowsToMove
-            );
-            optimisedTables.push(newTable);
-            optimisedMeasurements.push({
-              ...measurement,
-              rowHeights: movedRowMeasurements,
-              totalHeight: movedRowMeasurements.reduce(
-                (sum, height) => sum + height,
-                0
-              ),
+    /**
+     * Measures the heights of rows in a table.
+     * @param rows The rows to measure.
+     * @param pos The position of the table in the document.
+     * @param view The editor view.
+     * @returns An array of row heights.
+     */
+    private measureRowHeights(rows: PMNode[], pos: number, view: EditorView): number[] {
+        const dom = view.nodeDOM(pos) as HTMLElement;
+        if (dom) {
+            const trs = dom.querySelectorAll("tr");
+            return rows.map((row, index) => {
+                const { height } = trs[index].getBoundingClientRect();
+                return height || row.nodeSize;
             });
-          }
         }
-      }
+        // Fallback to using nodeSize if DOM is not available
+        const firstRow = rows[0];
+        const table = firstRow.type.name === "table" ? firstRow : firstRow.parent;
+        if (!table) {
+            return rows.map((row) => row.nodeSize);
+        }
+        // If table exists but DOM is not available, use nodeSize
+        return rows.map((row) => row.nodeSize);
+    }
 
-      if (measurement.totalHeight < availableSpace && tables[nextRowIndex]) {
-        const availableHeight = availableSpace - measurement.totalHeight;
-        const nextTable = tables[nextRowIndex];
-        const nextTableMeasurements = measurements[nextRowIndex];
-        const nextTableRows = nextTable.content.content;
-        const rowsToMove: PMNode[] = [];
-        const movedRowMeasurements: number[] = [];
-        let totalSpaceTaken = 0;
-        let rowsToAdd = 0;
+    private getHeaderRowCount(node: PMNode): number {
+        return node.attrs.headerRows || 0;
+    }
 
-        for (let i = 0; i < nextTableRows.length; i++) {
-          const rowHeight = nextTableMeasurements.rowHeights[i];
-          if (availableHeight - totalSpaceTaken <= rowHeight) break;
+    /**
+     * Split a table at a given height.
+     * @param tableNode The table node to split.
+     * @param availableHeight The available height for the table.
+     * @param measurement The measurement of the table.
+     * @param schema The schema of the document.
+     * @param pageHeight The height of the page.
+     * @returns The split result containing the tables, measurements, and mapping.
+     */
+    splitTableAtHeight(
+        tableNode: PMNode,
+        availableHeight: number,
+        measurement: TableMeasurement,
+        schema: Schema,
+        pageHeight: number
+    ): TableSplitResult {
+        const rows = tableNode.content.content;
+        const headerRowCount = this.getHeaderRowCount(tableNode);
+        const tables: PMNode[] = [];
+        const measurements: TableMeasurement[] = [];
+        let mapping: { from: number; to: number }[] = [];
 
-          rowsToMove.push(nextTableRows[i]);
-          movedRowMeasurements.push(rowHeight);
-          totalSpaceTaken += rowHeight;
-          rowsToAdd++;
+        // Check if table is already part of a group
+        const groupId = `table-group-${Date.now()}`;
+
+        // If table fits in available height, return as is with groupId
+        if (measurement.totalHeight <= availableHeight) {
+            const table = schema.nodes.table.create(
+                {
+                    ...tableNode.attrs,
+                    groupId,
+                },
+                tableNode.content
+            );
+            return {
+                tables: [table],
+                mapping: [],
+                groupId,
+                measurements: [measurement],
+            };
         }
 
-        if (rowsToAdd) {
-          isOptimised = true;
-          // push current table optimised
-          const rows = [...table.content.content, ...rowsToMove];
-          optimisedTables.push(
-            schema.nodes.table.create({ ...table.attrs }, rows)
-          );
-          optimisedMeasurements.push({
-            ...nextTableMeasurements,
-            totalHeight: measurement.totalHeight + totalSpaceTaken,
-            rowHeights: measurement.rowHeights.slice(0, rowsToAdd),
-            cumulativeHeights: [
-              ...measurement.cumulativeHeights,
-              ...nextTableMeasurements.cumulativeHeights.slice(0, rowsToAdd),
-            ],
-          });
+        // Find split point for current page
+        let splitIndex = headerRowCount;
+        let currentHeight = measurement.rowHeights.slice(0, headerRowCount).reduce((a, b) => a + b, 0);
 
-          // remove rows from next table
-          tables[nextRowIndex] = schema.nodes.table.create(
-            { ...nextTable.attrs },
-            nextTableRows.slice(rowsToAdd)
-          );
-          measurements[nextRowIndex].rowHeights =
-            measurements[nextRowIndex].rowHeights.slice(rowsToAdd);
-          measurements[nextRowIndex].cumulativeHeights =
-            measurements[nextRowIndex].cumulativeHeights.slice(rowsToAdd);
-          measurements[nextRowIndex].totalHeight -= totalSpaceTaken;
+        for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
+            if (currentHeight + measurement.rowHeights[i] > availableHeight) {
+                break;
+            }
+            currentHeight += measurement.rowHeights[i];
+            splitIndex = i + 1;
         }
-      }
 
-      if (!isOptimised) {
-        optimisedTables.push(table);
-        optimisedMeasurements.push(measurement);
-      }
-    });
+        // Create first table with header rows
+        const firstTableRows = rows.slice(0, splitIndex);
+        const firstTable = schema.nodes.table.create(
+            {
+                ...tableNode.attrs,
+                groupId,
+            },
+            firstTableRows
+        );
+        tables.push(firstTable);
+        measurements.push({
+            headerRowCount: 0,
+            breakPoints: [],
+            rowHeights: measurement.rowHeights.slice(0, splitIndex),
+            cumulativeHeights: measurement.cumulativeHeights.slice(0, splitIndex),
+            totalHeight: measurement.rowHeights.slice(0, splitIndex).reduce((a, b) => a + b, 0),
+        });
 
-    return { tables: optimisedTables, measurements: optimisedMeasurements };
-  }
+        // Handle remaining rows
+        if (splitIndex < rows.length) {
+            const remainingRows = rows.slice(splitIndex);
+            const remainingTable = schema.nodes.table.create(
+                {
+                    ...tableNode.attrs,
+                    groupId,
+                },
+                remainingRows
+            );
+
+            // Calculate remaining table measurement
+            const remainingMeasurement = {
+                ...measurement,
+                rowHeights: measurement.rowHeights.slice(splitIndex),
+                cumulativeHeights: measurement.cumulativeHeights.slice(splitIndex).map((h) => h - currentHeight),
+                totalHeight: measurement.rowHeights.slice(splitIndex).reduce((a, b) => a + b, 0),
+            };
+
+            // Recursively split remaining table if needed
+            if (remainingMeasurement.totalHeight > pageHeight) {
+                const result = this.splitTableAtHeight(remainingTable, pageHeight, remainingMeasurement, schema, pageHeight);
+
+                // Adjust mapping for the offset caused by the first table
+                const firstTableSize = firstTable.nodeSize;
+                const adjustedMapping = result.mapping.map(({ from, to }) => ({
+                    from: from + splitIndex,
+                    to: to + firstTableSize,
+                }));
+
+                tables.push(...result.tables);
+                measurements.push(...result.measurements);
+                mapping = [...mapping, ...adjustedMapping];
+            } else {
+                measurements.push(remainingMeasurement);
+                tables.push(remainingTable);
+            }
+        }
+
+        // Store or update table group
+        const originalTable = tableNode.attrs.groupId
+            ? this.tableGroups.get(tableNode.attrs.groupId)?.originalTable || tableNode
+            : tableNode;
+
+        this.tableGroups.set(groupId, {
+            tables,
+            originalTable,
+            positions: [], // Positions will be updated in buildNewDocument
+        });
+
+        return { tables, mapping, groupId, measurements };
+    }
+
+    /**
+     * Function to optimise a group of split tables by checking the length of the table and moving the rows between tables.
+     * @param tables The table(s) in a group which need to be checked.
+     * @param measurements The measurements of each table
+     * @param schema The schema of the document.
+     * @param availableHeight The available height in the current page
+     * @param pageHeight The height of a page.
+     * @returns The optimised tables, measurements, and updated mapping.
+     */
+    optimiseTables(tables: PMNode[], measurements: TableMeasurement[], schema: Schema, availableHeight: number, pageHeight: number) {
+        const optimisedTables: PMNode[] = [];
+        const optimisedMeasurements: TableMeasurement[] = [];
+
+        tables.forEach((table, index) => {
+            let isOptimised: boolean = false;
+            const nextRowIndex = index + 1;
+            const measurement = measurements[index];
+            const tableHeight = measurement.totalHeight;
+            const availableSpace = index === 0 ? availableHeight : pageHeight;
+
+            // handle overflows
+            if (measurement.totalHeight > availableSpace) {
+                const rows = table.content.content;
+                const rowsToMove: PMNode[] = [];
+                const movedRowMeasurements: number[] = [];
+                let totalSpaceTaken = 0;
+                let rowsToRemove = 0;
+
+                for (let i = rows.length - 1; i >= 0; i--) {
+                    const rowHeight = measurement.rowHeights[i];
+
+                    if (tableHeight - totalSpaceTaken <= availableSpace) break;
+
+                    rowsToMove.unshift(rows[i]);
+                    movedRowMeasurements.unshift(rowHeight);
+                    totalSpaceTaken += rowHeight;
+                    rowsToRemove++;
+                }
+
+                if (rowsToMove.length) {
+                    isOptimised = true;
+                    // Create new content for the current table
+                    optimisedTables.push(schema.nodes.table.create({ ...table.attrs }, rows.slice(0, -rowsToMove.length)));
+                    // add a new measurement for the adjusted table
+                    optimisedMeasurements.push({
+                        rowHeights: measurement.rowHeights.slice(0, -rowsToMove.length),
+                        headerRowCount: 0,
+                        totalHeight: measurement.totalHeight - totalSpaceTaken,
+                        breakPoints: measurement.breakPoints,
+                        cumulativeHeights: measurement.cumulativeHeights.slice(0, -rowsToMove.length),
+                    });
+
+                    if (tables[nextRowIndex]) {
+                        const nextTable = tables[nextRowIndex];
+                        const rows = [...rowsToMove, ...nextTable.content.content];
+                        // replaces next child so this is repeated
+                        tables[nextRowIndex] = schema.nodes.table.create({ ...nextTable.attrs }, rows);
+                        measurements[nextRowIndex].rowHeights.unshift(...movedRowMeasurements);
+                        measurements[nextRowIndex].totalHeight += totalSpaceTaken;
+                    } else {
+                        const newTable = schema.nodes.table.create({ ...table.attrs }, rowsToMove);
+                        optimisedTables.push(newTable);
+                        optimisedMeasurements.push({
+                            ...measurement,
+                            rowHeights: movedRowMeasurements,
+                            totalHeight: movedRowMeasurements.reduce((sum, height) => sum + height, 0),
+                        });
+                    }
+                }
+            }
+
+            if (measurement.totalHeight < availableSpace && tables[nextRowIndex]) {
+                const availableHeight = availableSpace - measurement.totalHeight;
+                const nextTable = tables[nextRowIndex];
+                const nextTableMeasurements = measurements[nextRowIndex];
+                const nextTableRows = nextTable.content.content;
+                const rowsToMove: PMNode[] = [];
+                const movedRowMeasurements: number[] = [];
+                let totalSpaceTaken = 0;
+                let rowsToAdd = 0;
+
+                for (let i = 0; i < nextTableRows.length; i++) {
+                    const rowHeight = nextTableMeasurements.rowHeights[i];
+                    if (availableHeight - totalSpaceTaken <= rowHeight) break;
+
+                    rowsToMove.push(nextTableRows[i]);
+                    movedRowMeasurements.push(rowHeight);
+                    totalSpaceTaken += rowHeight;
+                    rowsToAdd++;
+                }
+
+                if (rowsToAdd) {
+                    isOptimised = true;
+                    // push current table optimised
+                    const rows = [...table.content.content, ...rowsToMove];
+                    optimisedTables.push(schema.nodes.table.create({ ...table.attrs }, rows));
+                    optimisedMeasurements.push({
+                        ...nextTableMeasurements,
+                        totalHeight: measurement.totalHeight + totalSpaceTaken,
+                        rowHeights: measurement.rowHeights.slice(0, rowsToAdd),
+                        cumulativeHeights: [
+                            ...measurement.cumulativeHeights,
+                            ...nextTableMeasurements.cumulativeHeights.slice(0, rowsToAdd),
+                        ],
+                    });
+
+                    // remove rows from next table
+                    tables[nextRowIndex] = schema.nodes.table.create({ ...nextTable.attrs }, nextTableRows.slice(rowsToAdd));
+                    measurements[nextRowIndex].rowHeights = measurements[nextRowIndex].rowHeights.slice(rowsToAdd);
+                    measurements[nextRowIndex].cumulativeHeights = measurements[nextRowIndex].cumulativeHeights.slice(rowsToAdd);
+                    measurements[nextRowIndex].totalHeight -= totalSpaceTaken;
+                }
+            }
+
+            if (!isOptimised) {
+                optimisedTables.push(table);
+                optimisedMeasurements.push(measurement);
+            }
+        });
+
+        return { tables: optimisedTables, measurements: optimisedMeasurements };
+    }
 }

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,159 +1,172 @@
-import { Node as PMNode } from '@tiptap/pm/model'
-import { EditorState } from '@tiptap/pm/state'
-import { EditorView } from '@tiptap/pm/view'
-
-export interface TableMeasurement {
-  rowHeights: number[]
-  headerRowCount: number
-  totalHeight: number
-  breakPoints: number[]
-  cumulativeHeights: number[]
-}
-
-interface TableSplitResult {
-  tables: PMNode[]
-  mapping: { from: number; to: number }[]
-  groupId: string
-  measurements: TableMeasurement[]
-}
-
-interface TableGroup {
-  tables: PMNode[]
-  originalTable: PMNode
-  positions: number[]
-}
+import { Node as PMNode, Schema } from "@tiptap/pm/model";
+import { EditorView } from "@tiptap/pm/view";
+import { TableGroup, TableMeasurement, TableSplitResult } from "../types/table";
 
 export class TableHandler {
-  private static instance: TableHandler
-  private measurementCache: Map<string, TableMeasurement> = new Map()
-  private tableGroups: Map<string, TableGroup> = new Map()
-  private originalTableMeasurements = new Map<string, number[]>()
+  private static instance: TableHandler;
+  private measurementCache: Map<string, TableMeasurement> = new Map();
+  private tableGroups: Map<string, TableGroup> = new Map();
 
+  /**
+   * Get the singleton instance of the TableHandler.
+   * @returns The singleton instance of the TableHandler.
+   */
   static getInstance(): TableHandler {
     if (!this.instance) {
-      this.instance = new TableHandler()
+      this.instance = new TableHandler();
     }
-    return this.instance
+    return this.instance;
   }
 
+  /**
+   * Get a cache key for a table node.
+   * @param node The table node.
+   * @returns The cache key as a string.
+   */
   private getTableCacheKey(node: PMNode): string {
-    // Include content size and JSON to ensure cache invalidation on content changes
-    return `${node.type.name}-${node.content.size}-${JSON.stringify(node.toJSON())}`
+    return `${node.type.name}-${node.content.size}-${JSON.stringify(
+      node.toJSON()
+    )}`;
   }
 
+  /**
+   * Measure the height of a table.
+   * @param node The table node.
+   * @param pos The position of the table in the document.
+   * @param view The editor view.
+   * @returns The measurement of the table.
+   */
   measureTable(node: PMNode, pos: number, view: EditorView): TableMeasurement {
-    const cacheKey = this.getTableCacheKey(node)
-    const cached = this.measurementCache.get(cacheKey)
-    if (cached) return cached
-    const rows = node.content.content
-    const rowHeights = this.measureRowHeights(rows, pos, view)
-    const headerRowCount = this.getHeaderRowCount(node)
+    const cacheKey = this.getTableCacheKey(node);
+    const cached = this.measurementCache.get(cacheKey);
+    if (cached) return cached;
+    const rows = node.content.content;
+    const rowHeights = this.measureRowHeights(rows, pos, view);
+    const headerRowCount = this.getHeaderRowCount(node);
 
     // Calculate cumulative heights
     const cumulativeHeights = rowHeights.reduce((acc, height) => {
-      const prev = acc[acc.length - 1] || 0
-      acc.push(prev + height)
-      return acc
-    }, [] as number[])
+      const prev = acc[acc.length - 1] ?? 0;
+      acc.push(prev + height);
+      return acc;
+    }, [] as number[]);
 
     const measurement = {
       rowHeights,
       headerRowCount,
-      totalHeight: cumulativeHeights[cumulativeHeights.length - 1] || 0,
+      totalHeight: cumulativeHeights[cumulativeHeights.length - 1] ?? 0,
       breakPoints: [],
       cumulativeHeights,
-    }
+    };
 
     // Only cache if we have valid measurements
     if (measurement.totalHeight > 0) {
-      this.measurementCache.set(cacheKey, measurement)
+      this.measurementCache.set(cacheKey, measurement);
     }
 
-    return measurement
+    return measurement;
   }
 
+  /**
+   * Measures the heights of rows in a table.
+   * @param rows The rows to measure.
+   * @param pos The position of the table in the document.
+   * @param view The editor view.
+   * @returns An array of row heights.
+   */
   private measureRowHeights(
     rows: PMNode[],
     pos: number,
-    view: EditorView,
+    view: EditorView
   ): number[] {
-    const dom = view.nodeDOM(pos) as HTMLElement
+    const dom = view.nodeDOM(pos) as HTMLElement;
     if (dom) {
-      const trs = dom.querySelectorAll('tr')
+      const trs = dom.querySelectorAll("tr");
       return rows.map((row, index) => {
-        const { height } = trs[index].getBoundingClientRect()
-        return height || row.nodeSize
-      })
+        const { height } = trs[index].getBoundingClientRect();
+        return height || row.nodeSize;
+      });
     }
-    // Get the group ID from the first row's parent table
-    const firstRow = rows[0]
-    const table = firstRow.type.name === 'table' ? firstRow : firstRow.parent
+    // Fallback to using nodeSize if DOM is not available
+    const firstRow = rows[0];
+    const table = firstRow.type.name === "table" ? firstRow : firstRow.parent;
     if (!table) {
-      return rows.map((row) => row.nodeSize)
+      return rows.map((row) => row.nodeSize);
     }
+    // If table exists but DOM is not available, use nodeSize
+    return rows.map((row) => row.nodeSize);
   }
 
   private getHeaderRowCount(node: PMNode): number {
-    return node.attrs.headerRows || 1
+    return node.attrs.headerRows || 0;
   }
 
+  /**
+   * Split a table at a given height.
+   * @param tableNode The table node to split.
+   * @param availableHeight The available height for the table.
+   * @param measurement The measurement of the table.
+   * @param schema The schema of the document.
+   * @param pageHeight The height of the page.
+   * @returns The split result containing the tables, measurements, and mapping.
+   */
   splitTableAtHeight(
-    node: PMNode,
+    tableNode: PMNode,
     availableHeight: number,
     measurement: TableMeasurement,
-    schema: EditorState['schema'],
-    pageHeight: number,
+    schema: Schema,
+    pageHeight: number
   ): TableSplitResult {
-    const rows = node.content.content
-    const headerRowCount = this.getHeaderRowCount(node)
-    const tables: PMNode[] = []
-    const measurements: TableMeasurement[] = []
-    let mapping: { from: number; to: number }[] = []
+    const rows = tableNode.content.content;
+    const headerRowCount = this.getHeaderRowCount(tableNode);
+    const tables: PMNode[] = [];
+    const measurements: TableMeasurement[] = [];
+    let mapping: { from: number; to: number }[] = [];
 
     // Check if table is already part of a group
-    const groupId = `table-group-${Date.now()}`
+    const groupId = `table-group-${Date.now()}`;
 
     // If table fits in available height, return as is with groupId
     if (measurement.totalHeight <= availableHeight) {
       const table = schema.nodes.table.create(
         {
-          ...node.attrs,
+          ...tableNode.attrs,
           groupId,
         },
-        node.content,
-      )
+        tableNode.content
+      );
       return {
         tables: [table],
         mapping: [],
         groupId,
         measurements: [measurement],
-      }
+      };
     }
 
     // Find split point for current page
-    let splitIndex = headerRowCount
+    let splitIndex = headerRowCount;
     let currentHeight = measurement.rowHeights
       .slice(0, headerRowCount)
-      .reduce((a, b) => a + b, 0)
+      .reduce((a, b) => a + b, 0);
 
     for (let i = headerRowCount; i < measurement.rowHeights.length; i++) {
       if (currentHeight + measurement.rowHeights[i] > availableHeight) {
-        break
+        break;
       }
-      currentHeight += measurement.rowHeights[i]
-      splitIndex = i + 1
+      currentHeight += measurement.rowHeights[i];
+      splitIndex = i + 1;
     }
 
     // Create first table with header rows
-    const firstTableRows = rows.slice(0, splitIndex)
+    const firstTableRows = rows.slice(0, splitIndex);
     const firstTable = schema.nodes.table.create(
       {
-        ...node.attrs,
+        ...tableNode.attrs,
         groupId,
       },
-      firstTableRows,
-    )
-    tables.push(firstTable)
+      firstTableRows
+    );
+    tables.push(firstTable);
     measurements.push({
       headerRowCount: 0,
       breakPoints: [],
@@ -162,18 +175,18 @@ export class TableHandler {
       totalHeight: measurement.rowHeights
         .slice(0, splitIndex)
         .reduce((a, b) => a + b, 0),
-    })
+    });
 
     // Handle remaining rows
     if (splitIndex < rows.length) {
-      const remainingRows = rows.slice(splitIndex)
+      const remainingRows = rows.slice(splitIndex);
       const remainingTable = schema.nodes.table.create(
         {
-          ...node.attrs,
+          ...tableNode.attrs,
           groupId,
         },
-        remainingRows,
-      )
+        remainingRows
+      );
 
       // Calculate remaining table measurement
       const remainingMeasurement = {
@@ -185,7 +198,7 @@ export class TableHandler {
         totalHeight: measurement.rowHeights
           .slice(splitIndex)
           .reduce((a, b) => a + b, 0),
-      }
+      };
 
       // Recursively split remaining table if needed
       if (remainingMeasurement.totalHeight > pageHeight) {
@@ -194,102 +207,93 @@ export class TableHandler {
           pageHeight,
           remainingMeasurement,
           schema,
-          pageHeight,
-        )
+          pageHeight
+        );
 
         // Adjust mapping for the offset caused by the first table
-        const firstTableSize = firstTable.nodeSize
+        const firstTableSize = firstTable.nodeSize;
         const adjustedMapping = result.mapping.map(({ from, to }) => ({
           from: from + splitIndex,
           to: to + firstTableSize,
-        }))
+        }));
 
-        tables.push(...result.tables)
-        measurements.push(...result.measurements)
-        mapping = [...mapping, ...adjustedMapping]
+        tables.push(...result.tables);
+        measurements.push(...result.measurements);
+        mapping = [...mapping, ...adjustedMapping];
       } else {
-        measurements.push(remainingMeasurement)
-        tables.push(remainingTable)
+        measurements.push(remainingMeasurement);
+        tables.push(remainingTable);
       }
     }
 
     // Store or update table group
-    const originalTable = node.attrs.groupId
-      ? this.tableGroups.get(node.attrs.groupId)?.originalTable || node
-      : node
+    const originalTable = tableNode.attrs.groupId
+      ? this.tableGroups.get(tableNode.attrs.groupId)?.originalTable || tableNode
+      : tableNode;
 
     this.tableGroups.set(groupId, {
       tables,
       originalTable,
       positions: [], // Positions will be updated in buildNewDocument
-    })
+    });
 
-    return { tables, mapping, groupId, measurements }
+    return { tables, mapping, groupId, measurements };
   }
 
   /**
-   * For each table in a group
-   * - compare against maxHeight (table 0 against available height, the rest aginast page heigt)
-   * - if the table overflows.
-   * -- then
-   * -- calculate overflow rows
-   * --- if next table exists
-   * ---- then move to next table
-   * --- else
-   * ---- create new table
-   * -- else if table underflows and next table
-   * --- get max fit rows in underflow from next table
-   * --- add to current table
-   * @param tables
-   * @param measurements
-   * @param schema
-   * @param availableHeight
-   * @param pageHeight
-   * @returns
+   * Function to optimise a group of split tables by checking the length of the table and moving the rows between tables.
+   * @param tables The table(s) in a group which need to be checked.
+   * @param measurements The measurements of each table
+   * @param schema The schema of the document.
+   * @param availableHeight The available height in the current page
+   * @param pageHeight The height of a page.
+   * @returns The optimised tables, measurements, and updated mapping.
    */
   optimiseTables(
     tables: PMNode[],
     measurements: TableMeasurement[],
-    schema: EditorState['schema'],
+    schema: Schema,
     availableHeight: number,
-    pageHeight: number,
+    pageHeight: number
   ) {
-    const optimisedTables: PMNode[] = []
-    const optimisedMeasurements: TableMeasurement[] = []
+    const optimisedTables: PMNode[] = [];
+    const optimisedMeasurements: TableMeasurement[] = [];
 
     tables.forEach((table, index) => {
-      let optimised = false
-      const rows = table.content.content
-      const measurement = measurements[index]
-      const tableHeight = measurement.totalHeight
-      const availableSpace = index === 0 ? availableHeight : pageHeight
+      let isOptimised: boolean = false;
+      const nextRowIndex = index + 1;
+      const measurement = measurements[index];
+      const tableHeight = measurement.totalHeight;
+      const availableSpace = index === 0 ? availableHeight : pageHeight;
 
       // handle overflows
       if (measurement.totalHeight > availableSpace) {
-        const maxFitSpace = availableSpace - tableHeight
-        const rows = table.content.content
-        const rowsToMove: PMNode[] = []
-        const movedRowMeasurements: number[] = []
-        let totalSpaceTaken = 0
-        let rowsToRemove = 0
-        for (let i = rows.length - 1; i >= 0; i--) {
-          const rowHeight = measurement.rowHeights[i]
-          if (tableHeight - totalSpaceTaken <= availableSpace) break
+        const rows = table.content.content;
+        const rowsToMove: PMNode[] = [];
+        const movedRowMeasurements: number[] = [];
+        let totalSpaceTaken = 0;
+        let rowsToRemove = 0;
 
-          rowsToMove.unshift(rows[i])
-          movedRowMeasurements.unshift(rowHeight)
-          totalSpaceTaken += rowHeight
-          rowsToRemove++
+        for (let i = rows.length - 1; i >= 0; i--) {
+          const rowHeight = measurement.rowHeights[i];
+
+          if (tableHeight - totalSpaceTaken <= availableSpace) break;
+
+          rowsToMove.unshift(rows[i]);
+          movedRowMeasurements.unshift(rowHeight);
+          totalSpaceTaken += rowHeight;
+          rowsToRemove++;
         }
+
         if (rowsToMove.length) {
-          optimised = true
+          isOptimised = true;
           // Create new content for the current table
           optimisedTables.push(
             schema.nodes.table.create(
               { ...table.attrs },
-              rows.slice(0, -rowsToMove.length),
-            ),
-          )
+              rows.slice(0, -rowsToMove.length)
+            )
+          );
           // add a new measurement for the adjusted table
           optimisedMeasurements.push({
             rowHeights: measurement.rowHeights.slice(0, -rowsToMove.length),
@@ -298,62 +302,67 @@ export class TableHandler {
             breakPoints: measurement.breakPoints,
             cumulativeHeights: measurement.cumulativeHeights.slice(
               0,
-              -rowsToMove.length,
+              -rowsToMove.length
             ),
-          })
+          });
 
-          if (tables[index + 1]) {
-            const nextTable = tables[index + 1]
-            const rows = [...rowsToMove, ...nextTable.content.content]
+          if (tables[nextRowIndex]) {
+            const nextTable = tables[nextRowIndex];
+            const rows = [...rowsToMove, ...nextTable.content.content];
             // replaces next child so this is repeated
-            tables[index + 1] = schema.nodes.table.create(
+            tables[nextRowIndex] = schema.nodes.table.create(
               { ...nextTable.attrs },
-              rows,
-            )
-            measurements[index + 1].rowHeights.unshift(...movedRowMeasurements)
-            measurements[index + 1].totalHeight += totalSpaceTaken
+              rows
+            );
+            measurements[nextRowIndex].rowHeights.unshift(
+              ...movedRowMeasurements
+            );
+            measurements[nextRowIndex].totalHeight += totalSpaceTaken;
           } else {
             const newTable = schema.nodes.table.create(
               { ...table.attrs },
-              rowsToMove,
-            )
-            optimisedTables.push(newTable)
+              rowsToMove
+            );
+            optimisedTables.push(newTable);
             optimisedMeasurements.push({
               ...measurement,
               rowHeights: movedRowMeasurements,
               totalHeight: movedRowMeasurements.reduce(
                 (sum, height) => sum + height,
-                0,
+                0
               ),
-            })
+            });
           }
         }
       }
-      if (measurement.totalHeight < availableSpace && tables[index + 1]) {
-        const availableHeight = availableSpace - measurement.totalHeight
-        const nextTable = tables[index + 1]
-        const nextTableMeasurements = measurements[index + 1]
-        const nextTableRows = nextTable.content.content
-        const rowsToMove: PMNode[] = []
-        const movedRowMeasurements: number[] = []
-        let totalSpaceTaken = 0
-        let rowsToAdd = 0
-        for (let i = 0; i < nextTableRows.length; i++) {
-          const rowHeight = nextTableMeasurements.rowHeights[i]
-          if (availableHeight - totalSpaceTaken <= rowHeight) break
 
-          rowsToMove.push(nextTableRows[i])
-          movedRowMeasurements.push(rowHeight)
-          totalSpaceTaken += rowHeight
-          rowsToAdd++
+      if (measurement.totalHeight < availableSpace && tables[nextRowIndex]) {
+        const availableHeight = availableSpace - measurement.totalHeight;
+        const nextTable = tables[nextRowIndex];
+        const nextTableMeasurements = measurements[nextRowIndex];
+        const nextTableRows = nextTable.content.content;
+        const rowsToMove: PMNode[] = [];
+        const movedRowMeasurements: number[] = [];
+        let totalSpaceTaken = 0;
+        let rowsToAdd = 0;
+
+        for (let i = 0; i < nextTableRows.length; i++) {
+          const rowHeight = nextTableMeasurements.rowHeights[i];
+          if (availableHeight - totalSpaceTaken <= rowHeight) break;
+
+          rowsToMove.push(nextTableRows[i]);
+          movedRowMeasurements.push(rowHeight);
+          totalSpaceTaken += rowHeight;
+          rowsToAdd++;
         }
+
         if (rowsToAdd) {
-          optimised = true
+          isOptimised = true;
           // push current table optimised
-          const rows = [...table.content.content, ...rowsToMove]
+          const rows = [...table.content.content, ...rowsToMove];
           optimisedTables.push(
-            schema.nodes.table.create({ ...table.attrs }, rows),
-          )
+            schema.nodes.table.create({ ...table.attrs }, rows)
+          );
           optimisedMeasurements.push({
             ...nextTableMeasurements,
             totalHeight: measurement.totalHeight + totalSpaceTaken,
@@ -362,27 +371,27 @@ export class TableHandler {
               ...measurement.cumulativeHeights,
               ...nextTableMeasurements.cumulativeHeights.slice(0, rowsToAdd),
             ],
-          })
+          });
 
           // remove rows from next table
-          tables[index + 1] = schema.nodes.table.create(
+          tables[nextRowIndex] = schema.nodes.table.create(
             { ...nextTable.attrs },
-            nextTableRows.slice(rowsToAdd),
-          )
-          measurements[index + 1].rowHeights =
-            measurements[index + 1].rowHeights.slice(rowsToAdd)
-          measurements[index + 1].cumulativeHeights =
-            measurements[index + 1].cumulativeHeights.slice(rowsToAdd)
-          measurements[index + 1].totalHeight -= totalSpaceTaken
+            nextTableRows.slice(rowsToAdd)
+          );
+          measurements[nextRowIndex].rowHeights =
+            measurements[nextRowIndex].rowHeights.slice(rowsToAdd);
+          measurements[nextRowIndex].cumulativeHeights =
+            measurements[nextRowIndex].cumulativeHeights.slice(rowsToAdd);
+          measurements[nextRowIndex].totalHeight -= totalSpaceTaken;
         }
       }
 
-      if (!optimised) {
-        optimisedTables.push(table)
-        optimisedMeasurements.push(measurement)
+      if (!isOptimised) {
+        optimisedTables.push(table);
+        optimisedMeasurements.push(measurement);
       }
-    })
+    });
 
-    return { tables: optimisedTables, measurements: optimisedMeasurements }
+    return { tables: optimisedTables, measurements: optimisedMeasurements };
   }
 }

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,6 +1,6 @@
 import { Node as PMNode, Schema } from "@tiptap/pm/model";
 import { EditorView } from "@tiptap/pm/view";
-import { TableGroup, TableMeasurement, TableSplitResult } from "../types/table";
+import { TableGroup, TableMapping, TableMeasurement, TableSplitResult } from "../types/table";
 import { TABLE_NODE_TYPE } from "../constants/table";
 
 export class TableHandler {
@@ -116,7 +116,7 @@ export class TableHandler {
         const headerRowCount = this.getHeaderRowCount(tableNode);
         const tables: PMNode[] = [];
         const measurements: TableMeasurement[] = [];
-        let mapping: { from: number; to: number }[] = [];
+        let mapping: TableMapping[] = [];
 
         const groupId = `table-group-${Date.now()}`;
 
@@ -349,5 +349,15 @@ export class TableHandler {
      */
     filterTablesWithContent(tables: PMNode[]): PMNode[] {
         return tables.filter(table => table?.type && table.type.name === TABLE_NODE_TYPE && table.content && table.content.content.length > 0);
+    }
+    
+    /**
+     * Calculate new base position
+     * @param cumulativeNewDocPos Current cumulutive position
+     * @param currentPageContent Page content
+     * @returns 
+     */
+    calculateNewBasePosition(cumulativeNewDocPos: number, currentPageContent: PMNode[]) {
+        return cumulativeNewDocPos + currentPageContent.slice(0, -1).reduce((sum, n) => sum + n.nodeSize, 0)
     }
 }


### PR DESCRIPTION
This PR addresses basic table splitting. see #43 

Future improvements
 - split rows where cells which are larger than a whole page. 

Note the table attributes need to be extended to support `groupId`

```ts

export default Table.extend({
  content: 'tableRow*',

  addOptions() {
    return {
      ...this.parent?.(),
      View: CustomTableView as any,
    }
  },

  addAttributes() {
    return {
      ...this.parent?.(),
      id: {
        default: null,
      },
      groupId: {
        default: null,
      },
    }
  }
```

Video is as part of umo-editor

https://github.com/user-attachments/assets/1ca89d4d-c4e1-4bf0-835e-1f6f1d061885

